### PR TITLE
Update development payu environment

### DIFF
--- a/environments/payu/environment_dev.yml
+++ b/environments/payu/environment_dev.yml
@@ -5,12 +5,8 @@ channels:
 dependencies:
   - python==3.10
   - f90nml
-  - gh
-  - git
   - nco
   - pytest
-  - openssh==10.0p1
-  - openssl==3.5.2
   - xarray
   - mule
   - um2nc


### PR DESCRIPTION
This PR updates the payu development environment to remove `gh`, `git`, `openssh` and `openssl` from the environment specification to match the currently deployed environments. 

Related to #19 