### PR TITLE
Skip workflow jobs for PR from forks

### DIFF
--- a/.github/workflows/closed_pr.yml
+++ b/.github/workflows/closed_pr.yml
@@ -16,7 +16,15 @@ on:
 env:
   TEST_ENV: ${{ vars.TEST_ENV }}
 
-jobs:
+jobs:  
+  # We want to skip this workflow for PRs from forks
+  check_pr_from_fork:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    continue-on-error: true
+    steps:
+      - run: exit 1
+
   # In general, this workflow should always be "in sync" with the `deploy_env.yml` workflow.
   # This means that for the env deletion and deployment to DEVELOPMENT PRODUCTION, this
   # workflow should follow the same logic that is used in the `deploy_env.yml` workflow to detect
@@ -26,6 +34,8 @@ jobs:
   parse_changed_files:
     name: Parse changed files
     runs-on: ubuntu-latest
+    needs: check_pr_from_fork
+    if: needs.check_pr_from_fork.result == 'skipped'
     outputs:
       containers: ${{ steps.changed-files.outputs.containers }}
       dev_envs: ${{ steps.changed-files.outputs.dev_envs }}
@@ -44,7 +54,8 @@ jobs:
   get-environments:
     name: Get environments
     runs-on: ubuntu-latest
-    needs: [parse_changed_files]
+    needs: [parse_changed_files, check_pr_from_fork]
+    if: needs.check_pr_from_fork.result == 'skipped'
     outputs:
       envs_to_delete: ${{ steps.get-environments.outputs.envs_to_delete }}
       envs_to_deploy: ${{ steps.get-environments.outputs.envs_to_deploy }}
@@ -86,11 +97,11 @@ jobs:
   set_version:
     name: Set version
     runs-on: ubuntu-latest
-    needs: get-environments
+    needs: [check_pr_from_fork, get-environments]
     outputs:
       version: ${{ steps.set-version.outputs.version }}
     # Only run if there are envs to deploy
-    if: needs.get-environments.outputs.envs_to_deploy != '[]'
+    if: needs.get-environments.outputs.envs_to_deploy != '[]' && needs.check_pr_from_fork.result == 'skipped'
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -103,9 +114,12 @@ jobs:
   
   deploy_development_production:
     name: Deploy DEVELOPMENT ${{ matrix.environment }} environment to PRODUCTION
-    needs: [get-environments, set_version]
+    needs: [check_pr_from_fork, get-environments, set_version]
     # Only run if the PR was merged (not closed without merging)
-    if: needs.get-environments.outputs.envs_to_deploy != '[]' && github.event.pull_request.merged == true
+    if: >- 
+      needs.get-environments.outputs.envs_to_deploy != '[]' &&
+      github.event.pull_request.merged == true &&
+      needs.check_pr_from_fork.result == 'skipped'
     strategy:
       matrix:
         environment: ${{ fromJson(needs.get-environments.outputs.envs_to_deploy) }}
@@ -120,8 +134,8 @@ jobs:
   
   delete_staging_environments:
     name: Delete STAGING environments deployed from PR ${{ github.event.pull_request.number }}
-    needs: [get-environments]
-    if: needs.get-environments.outputs.envs_to_delete != '[]'
+    needs: [check_pr_from_fork, get-environments]
+    if: needs.get-environments.outputs.envs_to_delete != '[]' && needs.check_pr_from_fork.result == 'skipped'
     strategy:
       matrix:
         environment: ${{ fromJson(needs.get-environments.outputs.envs_to_delete) }}

--- a/.github/workflows/closed_pr.yml
+++ b/.github/workflows/closed_pr.yml
@@ -23,7 +23,7 @@ jobs:
     if: github.event.pull_request.head.repo.full_name == github.repository
     continue-on-error: true
     steps:
-      - run: exit 1
+      - run: echo "::warning::This PR comes from a fork. This workflow was skipped."
 
   # In general, this workflow should always be "in sync" with the `deploy_env.yml` workflow.
   # This means that for the env deletion and deployment to DEVELOPMENT PRODUCTION, this

--- a/.github/workflows/deploy_to_staging.yml
+++ b/.github/workflows/deploy_to_staging.yml
@@ -28,9 +28,19 @@ env:
   COMMENT_LABEL: 'deployment-${{ github.sha }}'
 
 jobs:
+  # We want to skip this workflow for PRs from forks
+  check_pr_from_fork:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    continue-on-error: true
+    steps:
+      - run: exit 1
+
   parse_changed_files:
     name: Parse changed files
     runs-on: ubuntu-latest
+    needs: check_pr_from_fork
+    if: needs.check_pr_from_fork.result == 'skipped'
     outputs:
       containers: ${{ steps.changed-files.outputs.containers }}
       dev_envs: ${{ steps.changed-files.outputs.dev_envs }}
@@ -49,7 +59,8 @@ jobs:
   sanity_checks:
     name: Sanity checks
     runs-on: ubuntu-latest
-    needs: parse_changed_files
+    needs: [parse_changed_files, check_pr_from_fork]
+    if: needs.check_pr_from_fork.result == 'skipped'
     env:
       CONTAINERS_CHANGES: ${{ needs.parse_changed_files.outputs.containers }}
       NON_CONTAINERS_CHANGES: ${{ needs.parse_changed_files.outputs.non_containers }}
@@ -70,6 +81,8 @@ jobs:
   get-date:
     name: Get current date
     runs-on: ubuntu-latest
+    needs: check_pr_from_fork
+    if: needs.check_pr_from_fork.result == 'skipped'
     outputs:
       date: ${{ steps.get-date.outputs.date }}
     steps:
@@ -82,7 +95,8 @@ jobs:
   get-environments:
     name: Get environments
     runs-on: ubuntu-latest
-    needs: [parse_changed_files, sanity_checks]
+    needs: [parse_changed_files, sanity_checks, check_pr_from_fork]
+    if: needs.check_pr_from_fork.result == 'skipped'
     outputs:
       dev_envs: ${{ steps.get-environments.outputs.dev_envs }}
       stable_envs: ${{ steps.get-environments.outputs.stable_envs }}
@@ -115,11 +129,11 @@ jobs:
   set_version_dev:
     name: Set version for DEVELOPMENT environments
     runs-on: ubuntu-latest
-    needs: get-environments
+    needs: [get-environments, check_pr_from_fork]
     outputs:
       version: ${{ steps.set-version.outputs.version }}
     # Only run if there are envs to deploy
-    if: needs.get-environments.outputs.dev_envs != '[]'
+    if: needs.get-environments.outputs.dev_envs != '[]' && needs.check_pr_from_fork.result == 'skipped'
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -133,11 +147,11 @@ jobs:
   set_version_stable:
     name: Set version for STABLE environments
     runs-on: ubuntu-latest
-    needs: get-environments
+    needs: [get-environments, check_pr_from_fork]
     outputs:
       version: ${{ steps.set-version.outputs.version }}
     # Only run if there are envs to deploy
-    if: needs.get-environments.outputs.stable_envs != '[]'
+    if: needs.get-environments.outputs.stable_envs != '[]' && needs.check_pr_from_fork.result == 'skipped'
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -150,7 +164,8 @@ jobs:
 
   deploy_development_staging:
     name: Deploy DEVELOPMENT ${{ matrix.environment }} environment to STAGING
-    needs: [get-environments, set_version_dev]
+    needs: [get-environments, set_version_dev, check_pr_from_fork]
+    if: needs.check_pr_from_fork.result == 'skipped'
     strategy:
       matrix:
         environment: ${{ fromJson(needs.get-environments.outputs.dev_envs) }}
@@ -166,7 +181,8 @@ jobs:
   
   deploy_stable_staging:
     name: Deploy STABLE ${{ matrix.environment }} environment to STAGING
-    needs: [get-environments, set_version_stable]
+    needs: [get-environments, set_version_stable, check_pr_from_fork]
+    if: needs.check_pr_from_fork.result == 'skipped'
     strategy:
       matrix:
         environment: ${{ fromJson(needs.get-environments.outputs.stable_envs) }}
@@ -183,9 +199,12 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
-    needs: [set_version_dev,set_version_stable]
+    needs: [set_version_dev,set_version_stable,check_pr_from_fork]
     # Run if at least one of set_version_dev or set_version_stable succeeded and neither failed
-    if: always() && !failure() && !cancelled() && (needs.set_version_dev.result == 'success' || needs.set_version_stable.result == 'success')
+    if: >-
+      always() && !failure() && !cancelled() &&
+      (needs.set_version_dev.result == 'success' || needs.set_version_stable.result == 'success') &&
+      needs.check_pr_from_fork.result == 'skipped'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -217,9 +236,12 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
-    needs: [get-date, deploy_development_staging, deploy_stable_staging, initialise_pr_comment]
+    needs: [get-date, deploy_development_staging, deploy_stable_staging, initialise_pr_comment, check_pr_from_fork]
     # Run if initialise_pr_comment is successful
-    if: always() && !cancelled() && needs.initialise_pr_comment.result == 'success'
+    if: >-
+      always() && !cancelled() &&
+      needs.initialise_pr_comment.result == 'success' &&
+      needs.check_pr_from_fork.result == 'skipped'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -268,9 +290,12 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
-    needs: [get-date, initialise_pr_comment, deploy_development_staging, deploy_stable_staging]
+    needs: [get-date, initialise_pr_comment, deploy_development_staging, deploy_stable_staging, check_pr_from_fork]
     # Run if the workflow was cancelled and initialise_pr_comment is successful
-    if: cancelled() && needs.initialise_pr_comment.result == 'success'
+    if: >-
+      cancelled() &&
+      needs.initialise_pr_comment.result == 'success' &&
+      needs.check_pr_from_fork.result == 'skipped'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/deploy_to_staging.yml
+++ b/.github/workflows/deploy_to_staging.yml
@@ -32,9 +32,8 @@ jobs:
   check_pr_from_fork:
     runs-on: ubuntu-latest
     if: github.event.pull_request.head.repo.full_name == github.repository
-    continue-on-error: true
     steps:
-      - run: exit 1
+      - run: echo "::warning::This PR comes from a fork. This workflow was skipped."
 
   parse_changed_files:
     name: Parse changed files

--- a/.github/workflows/test_message_rendering.yml
+++ b/.github/workflows/test_message_rendering.yml
@@ -27,8 +27,18 @@ env:
   JQ_EXE: jq
 
 jobs:
+  # We want to skip this workflow for PRs from forks
+  check_pr_from_fork:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    continue-on-error: true
+    steps:
+      - run: exit 1
+
   create_hpc_target_deployment_info_jsons:
     runs-on: ubuntu-latest
+    needs: check_pr_from_fork
+    if: needs.check_pr_from_fork.result == 'skipped'
     strategy:
       matrix:
         include:
@@ -114,7 +124,8 @@ jobs:
           path: ${{ env.HPC_TARGET_DEPLOYMENT_INFO_JSON }}
   
   create_all_deployments_info:
-    needs: create_hpc_target_deployment_info_jsons
+    needs: [create_hpc_target_deployment_info_jsons, check_pr_from_fork]
+    if: needs.check_pr_from_fork.result == 'skipped'
     runs-on: ubuntu-latest
     env:
       ARTIFACTS_FOLDER: ${{ github.workspace }}/downloaded_artifacts
@@ -186,6 +197,8 @@ jobs:
     
   test_messages_with_pr_init_json:
     runs-on: ubuntu-latest
+    needs: check_pr_from_fork
+    if: needs.check_pr_from_fork.result == 'skipped'
     env:
         HPC_TARGET_DEPLOYMENT_INFO_JSON: ${{ github.workspace }}/pr_init_info.json
     steps:

--- a/.github/workflows/test_message_rendering.yml
+++ b/.github/workflows/test_message_rendering.yml
@@ -33,7 +33,7 @@ jobs:
     if: github.event.pull_request.head.repo.full_name == github.repository
     continue-on-error: true
     steps:
-      - run: exit 1
+      - run: echo "::warning::This PR comes from a fork. This workflow was skipped."
 
   create_hpc_target_deployment_info_jsons:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR updates the workflows that trigger `on: pull_request` to prevent them from running their jobs when the PR comes from a fork.

The solution I though about is setting a job at the beginning of each workflow, that only runs if the PR comes from a fork:
```yaml
check_pr_from_fork:
  runs-on: ubuntu-latest
  if: github.event.pull_request.head.repo.full_name == github.repository
  continue-on-error: true
  steps:
    - run: exit 1
```

And the have all subsequent jobs be triggered on the condition `if: needs.check_pr_from_fork.result == 'skipped'`