### PR TITLE
Swapped module load singularity for its binary executable path

### DIFF
--- a/defaults/modules/modulefile
+++ b/defaults/modules/modulefile
@@ -11,6 +11,3 @@ prepend-path PATH "__ENV_BIN_DIR__"
 # (e.g., to change the PS1 after the module is loaded)
 setenv CONDA_PROMPT_MODIFIER "__ENV_PROMPT_MODIFIER__"
 setenv CONDA_PREFIX "__INTERNAL_ENV_DIR__"
-
-# Load singularity
-module load singularity

--- a/defaults/scripts/launcher.sh
+++ b/defaults/scripts/launcher.sh
@@ -27,7 +27,7 @@ if [ "$(basename "$CMD")" == "$original_launcher_script_name" ]; then
     fi
 fi
 
-# If this script gets run within the container,  we should not call another 
+# If this script gets run within the container, we should not call another 
 # singularity container, but only run the command:
 if [ -n "$SINGULARITY_CONTAINER" ]; then
     exec -a "$CMD" "$(basename "$CMD")" "$@"
@@ -67,21 +67,15 @@ export SINGULARITYENV_PYTHONDONTWRITEBYTECODE='__PYTHONDONTWRITEBYTECODE__'
 # Set path to the environment activation script within the container
 export SINGULARITYENV_ENV_ACTIVATION_SCRIPT='__ACTIVATION_SCRIPT_PATH__'
 
+singularity_exe='__SINGULARITY_EXE__'
+
 function singularity_exec () {
-    exec singularity -s run \
+    exec "$singularity_exe" -s run \
       --bind "$bind_str" \
       "$overlay_str" \
       "$container_image_path" \
       "$CMD" "$@"
 }
-
-# Use latest singularity if needed
-if ! command -v singularity &> /dev/null; then
-    singularity_exe='__SINGULARITY_EXE__'
-    echo "Singularity could not be found, using latest singularity executable: $singularity_exe"
-    singularity_dir=$( dirname "$singularity_exe" )
-    export PATH="$singularity_dir:$PATH"
-fi
 
 singularity_exec "$@"
 exit $?

--- a/infrastructure/scripts/build_and_deploy_env.sh
+++ b/infrastructure/scripts/build_and_deploy_env.sh
@@ -100,13 +100,10 @@ add_to_bind=(
 # Use printf %q for safety with bash special characters like spaces.
 add_bind_str=$(printf ",%q" "${add_to_bind[@]}")
 
-# Initialise singularity
-module load -v singularity
-
 # Set host_executables as an array
 IFS=',' read -ra host_executables <<< "$HOST_EXECUTABLES"
 
-singularity -s exec \
+"$SINGULARITY_EXE" -s exec \
     --bind "${BIND_STR}${add_bind_str}" \
     "$RUNTIME_CONTAINER_IMAGE_PATH" \
     bash <<EOF

--- a/infrastructure/scripts/install_config.sh
+++ b/infrastructure/scripts/install_config.sh
@@ -264,7 +264,7 @@ if [[ "$DEPLOYMENT_STAGE" == PRODUCTION ]] || [[ "$DEPLOYMENT_STAGE" == STAGING 
     # Disable Python's bytecode cache (.pyc files)
     export PYTHONDONTWRITEBYTECODE=${PYTHONDONTWRITEBYTECODE:-1}
 
-    # Set directories to bind to the singularity container using --bind
+    # Set directories to bind to the container using --bind
     bind_dirs=(
         /etc
         /half-root


### PR DESCRIPTION
Fixes #33

To avoid incompatibilities with other loaded modules, instead of using relying on the load of the singularity module we use directly singularity's latest binary executable path.