### PR TITLE
Restricted um2nc version <2 in payu environment

### DIFF
--- a/environments/payu/environment.yml
+++ b/environments/payu/environment.yml
@@ -14,7 +14,7 @@ dependencies:
   - openssl==3.5.2
   - xarray
   - mule
-  - um2nc
+  - um2nc<2
   - accessnri::yamanifest
   - netcdf4=*=nompi_*
   - experiment-generator

--- a/environments/payu/environment_dev.yml
+++ b/environments/payu/environment_dev.yml
@@ -9,7 +9,7 @@ dependencies:
   - pytest
   - xarray
   - mule
-  - um2nc
+  - um2nc<2
   - accessnri::yamanifest
   - netcdf4=*=nompi_*
   - experiment-generator


### PR DESCRIPTION
Following [this issue](https://github.com/ACCESS-NRI/model-release-condaenv/issues/70), the version of `um2nc` was restricted to be `<2`