### PR TITLE
Fix first-installation micromamba error

### DIFF
--- a/infrastructure/scripts/build_and_deploy_env.sh
+++ b/infrastructure/scripts/build_and_deploy_env.sh
@@ -126,9 +126,7 @@ echo ''   # ensure newline after cat output
 "$MAMBA_EXE" create -y \
     --prefix "$INTERNAL_ENV_DIR" \
     --file "$ENV_FILE" \
-    --no-rc \
-    --no-env \
-    --root-prefix "$TEMP_WORKING_DIR"
+    --no-rc
 
 # Delete executables in host_executables
 for exe in "${host_executables[@]}"; do

--- a/infrastructure/scripts/install_config.sh
+++ b/infrastructure/scripts/install_config.sh
@@ -203,35 +203,20 @@ if [[ "$DEPLOYMENT_STAGE" == PRODUCTION ]] || [[ "$DEPLOYMENT_STAGE" == STAGING 
     export MAX_DEV_ENV_VERSIONS=3
 
     ### Micromamba initialisation
-    # MAMBA_RUNTIME_EXE is the micromamba executable used to manage environments at runtime (not within the build/deployment!)
-    export MAMBA_RUNTIME_EXE="$containerised_envs_root_dir/micromamba_installation/micromamba"
-    export MAMBA_EXE="${MAMBA_EXE:-$MAMBA_RUNTIME_EXE}"
-    # If MAMBA_RUNTIME_EXE is not defined or not found, a temporary micromamba executable (mamba_deployment_exe) gets installed
-    # for the build/deployment. This executable will then be copied to the MAMBA_RUNTIME_EXE path to be used at runtime.
-    # We install a temporary unique micromamba executable to avoid clashes with multiple installation of the same
-    # micromamba executable happening at the same time.
-    mamba_deployment_exe="$TEMP_WORKING_DIR/micromamba"
-    # If the micromamba executable is not found or not executable, the latest version is installed
+    export MAMBA_EXE="${MAMBA_EXE:-}"
+    export MAMBA_ROOT_PREFIX="$TEMP_WORKING_DIR/micromamba_root"
+    # If MAMBA_EXE is not defined or not found, a temporary micromamba executable gets installed
+    # for the build/deployment.
     if [ ! -x "$MAMBA_EXE" ]; then
-        if [ ! -f "$MAMBA_EXE" ]; then # Micromamba exe not found
-            echo "Micromamba executable '$MAMBA_EXE' not found."
-        else # Micromamba exe not executable
-            echo "Micromamba executable '$MAMBA_EXE' is not executable."
-        fi
+        echo "Micromamba executable '$MAMBA_EXE' not found or not executable."
         echo "Installing micromamba's latest version:"
+        mamba_temp_exe="$MAMBA_ROOT_PREFIX/micromamba"
         mamba_download_url='https://micro.mamba.pm/api/micromamba/linux-64/latest'
-        curl -L "$mamba_download_url" | tar -xvjO bin/micromamba > "$mamba_deployment_exe"
+        curl -L "$mamba_download_url" | tar -xvjO bin/micromamba > "$mamba_temp_exe"
         # Set executable permissions
-        chmod u+x "$mamba_deployment_exe"
-        set_perms "$mamba_deployment_exe"
-        MAMBA_EXE="$mamba_deployment_exe"
-        # Copy the micromamba executable to the MAMBA_RUNTIME_EXE path to be used at runtime
-        # We double check that the destination directory exists before copying for race-condition
-        # when multiple envs are deployed at the same time
-        if [ ! -x "$MAMBA_RUNTIME_EXE" ]; then
-            mkdir -pv "$(dirname "$MAMBA_RUNTIME_EXE")"
-            cp -v "$MAMBA_EXE" "$MAMBA_RUNTIME_EXE"
-        fi
+        chmod u+x "$mamba_temp_exe"
+        set_perms "$mamba_temp_exe"
+        MAMBA_EXE="$mamba_temp_exe"
     fi
     echo "Using micromamba executable: $MAMBA_EXE"
     

--- a/infrastructure/scripts/install_config.sh
+++ b/infrastructure/scripts/install_config.sh
@@ -204,6 +204,8 @@ if [[ "$DEPLOYMENT_STAGE" == PRODUCTION ]] || [[ "$DEPLOYMENT_STAGE" == STAGING 
 
     ### Micromamba initialisation
     export MAMBA_EXE="${MAMBA_EXE:-}"
+    # Set MAMBA_ROOT_PREFIX to a temporary directory within the TEMP_WORKING_DIR
+    # MAMBA_ROOT_PREFIX in our case only controls conda packages caching
     export MAMBA_ROOT_PREFIX="$TEMP_WORKING_DIR/micromamba_root"
     mkdir -p "$MAMBA_ROOT_PREFIX"
     # If MAMBA_EXE is not defined or not found, a temporary micromamba executable gets installed

--- a/infrastructure/scripts/install_config.sh
+++ b/infrastructure/scripts/install_config.sh
@@ -205,6 +205,7 @@ if [[ "$DEPLOYMENT_STAGE" == PRODUCTION ]] || [[ "$DEPLOYMENT_STAGE" == STAGING 
     ### Micromamba initialisation
     export MAMBA_EXE="${MAMBA_EXE:-}"
     export MAMBA_ROOT_PREFIX="$TEMP_WORKING_DIR/micromamba_root"
+    mkdir -p "$MAMBA_ROOT_PREFIX"
     # If MAMBA_EXE is not defined or not found, a temporary micromamba executable gets installed
     # for the build/deployment.
     if [ ! -x "$MAMBA_EXE" ]; then


### PR DESCRIPTION
Fixes #45
- [x] Added `MAMBA_ROOT_PREFIX` as a temporary directory
- [x] Install micromamba executable (`MAMBA_EXE`) within the `MAMBA_ROOT_PREFIX` if it is not provided
- [x] Removed the copying of the micromamba executable to a permanent directory within the infrasturcture folder tree, as the micromamba executable is not needed at runtime
- [x] Removed `--no-env` from environment creation
