### PR TITLE
Fix permissions

### DIFF
--- a/.github/actions/set_up_hpc_target/action.yml
+++ b/.github/actions/set_up_hpc_target/action.yml
@@ -73,7 +73,6 @@ runs:
         vars_unset=false
         vars=(
           GROUP_OWNER
-          OWNER
           PBS_PROJECT
           PBS_STORAGE
           SINGULARITY_EXE

--- a/.github/workflows/delete_all_staging_environments.yml
+++ b/.github/workflows/delete_all_staging_environments.yml
@@ -40,7 +40,6 @@ jobs:
     environment: ${{ matrix.hpc-target }}
     env:
       GROUP_OWNER: '${{ vars.GROUP_OWNER }}'
-      OWNER: '${{ vars.OWNER }}'
       PBS_PROJECT: '${{ vars.PBS_PROJECT }}'
       PBS_STORAGE: '${{ vars.PBS_STORAGE }}'
       SINGULARITY_EXE: '${{ vars.SINGULARITY_EXE }}'

--- a/.github/workflows/deploy_env.yml
+++ b/.github/workflows/deploy_env.yml
@@ -144,7 +144,6 @@ jobs:
     environment: ${{ matrix.hpc-target }}
     env:
       GROUP_OWNER: '${{ vars.GROUP_OWNER }}'
-      OWNER: '${{ vars.OWNER }}'
       PBS_PROJECT: '${{ vars.PBS_PROJECT }}'
       PBS_STORAGE: '${{ vars.PBS_STORAGE }}'
       SINGULARITY_EXE: '${{ vars.SINGULARITY_EXE }}'

--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ Secrets required for SSH:
 
 - `secrets.HOST`: Hostname for the environment
 - `secrets.HOST_DATA`: Hostname for the data mover
-- `secrets.SSH_USER`: Username for the account used for deployment
+- `secrets.USER`: Username for the account used for deployment. This is also going to be the owner of the deployed files.
 - `secrets.SSH_KEY`: Private SSH key for the user
 
 Variables required for Build/Test/Deploy workflows:
@@ -296,7 +296,6 @@ Variables required for Build/Test/Deploy workflows:
 - `vars.BASE_DIR` - Base deployment directory that contains `apps/` and `modules/` subdirectories (e.g for `Gadi`: `/g/data/vk83` and for `Gadi Prerelease`: `/g/data/vk83/prerelease/`). **Note:** Currently, the build scripts expect `BASE_DIR` directory to be in `/g/data`.
 - `vars.ADMIN_DIR`: Directory to store staging and log files, and tar files of deployed conda environments (e.g. `/g/data/vk83/admin/conda_containers/prerelease`)
 - `vars.GROUP_OWNER`: Permissions of read and execute for files installed to apps and modules (e.g. `vk83`)
-- `vars.OWNER`: User with read, write, and execute permissions for installed files
 - `vars.PROJECT`: Project code used for build and test PBS jobs (e.g. `tm70`)
 - `vars.STORAGE`: Storage directives for build and test PBS jobs (e.g. `gdata/vk83`)
 - `secrets.PAYU_TELEMETRY_CONFIG`: Sets environment variable for the Payu telemetry configuration path which is passed to the launcher script configuration. This means this environment variable is set every time the container runs.

--- a/infrastructure/scripts/build_and_deploy_env.sh
+++ b/infrastructure/scripts/build_and_deploy_env.sh
@@ -154,7 +154,7 @@ first_internal_path_portion="${first_internal_path_portion%%/*}"
 env_path_truncated="$TEMP_WORKING_DIR/$first_internal_path_portion"
 
 # Set permissions within the squashfs
-set_perms "$env_path_truncated"
+set_perms -R "$env_path_truncated"
 
 # Pack the environment into squashfs
 mksquashfs "$env_path_truncated" "$TEMP_SQSH_FILE_PATH" \
@@ -228,6 +228,9 @@ echo "Environment lock created to: '$ENV_LOCK_FILE_PATH'"
 
 ### CLEANUP OLDEST DEVELOPMENT ENV FOR PRODUCTION
 source "$INFRA_SCRIPTS_DIR/cleanup_old_dev_env.sh"
+
+### ENSURE RIGHT PERMISSIONS RECURSIVELY FOR ENVIRONMENT VERSION
+set_perms -R "$ENV_VERSION_DIR"
 
 ### EXPORT ENV VARIABLES FOR HPC TARGET DEPLOYMENT INFO JSON (update_hpc_target_deployment_info trap function)
 # MODULE_USAGE_INSTRUCTIONS

--- a/infrastructure/scripts/build_and_deploy_env.sh
+++ b/infrastructure/scripts/build_and_deploy_env.sh
@@ -211,8 +211,7 @@ launcher_script=$(
 # Deploy launcher script and set permissions
 copy_if_changed_with_replace "$launcher_script" "$LAUNCHER_SCRIPT_PATH"
 # Add execute permissions to the launcher script
-chmod u+x "$LAUNCHER_SCRIPT_PATH"
-set_perms "$LAUNCHER_SCRIPT_PATH"
+set_perms "$LAUNCHER_SCRIPT_PATH" -x
 echo "Launcher script deployed to '$LAUNCHER_SCRIPT_PATH'"
 
 # Create symlinks to the launcher script for all binaries in the environment,

--- a/infrastructure/scripts/build_and_deploy_env.sh
+++ b/infrastructure/scripts/build_and_deploy_env.sh
@@ -104,7 +104,7 @@ add_bind_str=$(printf ",%q" "${add_to_bind[@]}")
 IFS=',' read -ra host_executables <<< "$HOST_EXECUTABLES"
 
 # Create the environment within the container
-"$SINGULARITY_EXEC" -s exec \
+"$SINGULARITY_EXE" -s exec \
     --bind "${BIND_STR}${add_bind_str}" \
     "$RUNTIME_CONTAINER_IMAGE_PATH" \
     bash <<EOF

--- a/infrastructure/scripts/build_and_deploy_env.sh
+++ b/infrastructure/scripts/build_and_deploy_env.sh
@@ -154,7 +154,7 @@ first_internal_path_portion="${first_internal_path_portion%%/*}"
 env_path_truncated="$TEMP_WORKING_DIR/$first_internal_path_portion"
 
 # Set permissions within the squashfs
-set_perms -R "$env_path_truncated"
+set_perms "$env_path_truncated"
 
 # Pack the environment into squashfs
 mksquashfs "$env_path_truncated" "$TEMP_SQSH_FILE_PATH" \
@@ -230,7 +230,7 @@ echo "Environment lock created to: '$ENV_LOCK_FILE_PATH'"
 source "$INFRA_SCRIPTS_DIR/cleanup_old_dev_env.sh"
 
 ### ENSURE RIGHT PERMISSIONS RECURSIVELY FOR ENVIRONMENT VERSION
-set_perms -R "$ENV_VERSION_DIR"
+set_perms "$ENV_VERSION_DIR"
 
 ### EXPORT ENV VARIABLES FOR HPC TARGET DEPLOYMENT INFO JSON (update_hpc_target_deployment_info trap function)
 # MODULE_USAGE_INSTRUCTIONS

--- a/infrastructure/scripts/build_and_deploy_env.sh
+++ b/infrastructure/scripts/build_and_deploy_env.sh
@@ -211,7 +211,7 @@ launcher_script=$(
 # Deploy launcher script and set permissions
 copy_if_changed_with_replace "$launcher_script" "$LAUNCHER_SCRIPT_PATH"
 # Add execute permissions to the launcher script
-set_perms "$LAUNCHER_SCRIPT_PATH" -x
+set_perms -x "$LAUNCHER_SCRIPT_PATH"
 echo "Launcher script deployed to '$LAUNCHER_SCRIPT_PATH'"
 
 # Create symlinks to the launcher script for all binaries in the environment,

--- a/infrastructure/scripts/build_and_deploy_env.sh
+++ b/infrastructure/scripts/build_and_deploy_env.sh
@@ -103,7 +103,8 @@ add_bind_str=$(printf ",%q" "${add_to_bind[@]}")
 # Set host_executables as an array
 IFS=',' read -ra host_executables <<< "$HOST_EXECUTABLES"
 
-"$SINGULARITY_EXE" -s exec \
+# Create the environment within the container
+"$SINGULARITY_EXEC" -s exec \
     --bind "${BIND_STR}${add_bind_str}" \
     "$RUNTIME_CONTAINER_IMAGE_PATH" \
     bash <<EOF
@@ -116,12 +117,10 @@ fi
 # Print environment specification for debugging purposes
 echo 'Creating environment using the following environment specification:'
 cat "$ENV_FILE"
-echo ''   # ensure newline after cat output
+echo '' # ensure newline after cat output for readability
 
 # Create the environment
 # We use --no-rc to disable the use of configuration files
-# We use --root-prefix to specify the cache packages dir, to avoid parallel 
-# env creation failing because mircomamba tries to access the cache at the same time
 "$MAMBA_EXE" create -y \
     --prefix "$INTERNAL_ENV_DIR" \
     --file "$ENV_FILE" \
@@ -224,7 +223,7 @@ done
 echo "Environment binaries linked to launcher script"
 
 ### GENERATE ENVIRONMENT LOCK
-source "$INFRA_SCRIPTS_DIR/generate_env_lock.sh" > "$ENV_LOCK_FILE_PATH"
+source "$INFRA_SCRIPTS_DIR/generate_env_lock.sh"
 echo "Environment lock created to: '$ENV_LOCK_FILE_PATH'"
 
 ### CLEANUP OLDEST DEVELOPMENT ENV FOR PRODUCTION

--- a/infrastructure/scripts/build_and_deploy_env.sh
+++ b/infrastructure/scripts/build_and_deploy_env.sh
@@ -120,7 +120,6 @@ echo ''   # ensure newline after cat output
 
 # Create the environment
 # We use --no-rc to disable the use of configuration files
-# We use --no-env to disable the use of environment variables
 # We use --root-prefix to specify the cache packages dir, to avoid parallel 
 # env creation failing because mircomamba tries to access the cache at the same time
 "$MAMBA_EXE" create -y \

--- a/infrastructure/scripts/functions.sh
+++ b/infrastructure/scripts/functions.sh
@@ -91,12 +91,12 @@ function in_array() {
 }
 
 function set_perms() {
-    # Set permissions to a provided file or directory.
+    # Set permissions to a provided file or directory (recursively).
     # Use the -x option to also set executable permissions for files.
 
     local OPTIND exec_perm arg
     
-    exec_perm='-'
+    exec_perm='X' # Default to capital X to retain existing executable permissions if -x is not provided
     while getopts ":x" opt; do
         case $opt in
             x) exec_perm=x ;;
@@ -122,7 +122,8 @@ function set_perms() {
 
     ### Files
     # Set ACLs only for files
-    # rw- for user, r-- for group, none for others
+    # rwX for user, r-X for group, none for others (if -x option is NOT provided)
+    # rwx for user, r-x for group, none for others (if -x option is provided)
     find "$arg" -type f \
         -exec setfacl -m u::rw${exec_perm},g::r-${exec_perm},o::--- {} \;
 }

--- a/infrastructure/scripts/functions.sh
+++ b/infrastructure/scripts/functions.sh
@@ -91,36 +91,40 @@ function in_array() {
 }
 
 function set_perms() {
-    # Set the permissions for each of the provided arguments
-    local arg
-    for arg in "$@"; do
-        if [[ -L "${arg}" ]]; then # Links
-            # Change group ownership for the link (not the file it points to)
-            chgrp -h "${GROUP_OWNER}" "${arg}"
-        elif [[ -d "${arg}" ]]; then # Directories
-            # Change group ownership recursively
-            chgrp -R "${GROUP_OWNER}" "${arg}"
-            # Set group permissions recursively to match user permissions without "write"
-            # and remove all permissions for others
-            chmod -R g=u-w,o= "${arg}"
-            # Set group ID bit, to have all children files and directories inherit the directory's group
-            chmod g+s "${arg}"
-            # Set specific permissions to OWNER recursively to read, write and execute 
-            # (only if someone else already has execute) permissions, also for new files and directories
-            setfacl -R -m u:"${OWNER}":rwX,d:u:"${OWNER}":rwX "${arg}"
-        elif [[ -f "${arg}" ]]; then # Files
-            # reset any existing acls
-            setfacl -b "${arg}"
-            # Change group ownership
-            chgrp "${GROUP_OWNER}" "${arg}"
-            # Set group permissions to match user permissions without "write"
-            # and remove all permissions for others
-            chmod g=u-w,o= "${arg}"
-            # Set specific permissions to OWNER to read, write and execute 
-            # (only if someone else already has execute) permissions
-            setfacl -m u:"${OWNER}":rwX "${arg}"
-        fi
+    # Set permissions to a provided file or directory.
+    # Use the -x option to also set executable permissions for files.
+
+    local exec_perm arg
+    
+    exec_perm='-'
+    while getopts ":x" opt; do
+        case $opt in
+            x) exec_perm=x ;;
+            \?) echo "Invalid option: -$OPTARG" >&2; return 1 ;;
+        esac
     done
+    shift $((OPTIND - 1))
+    arg="$1"
+
+    # Change group owner of files and directories recursively
+    # (-h option to change symbolic links themselves and not the link they point to)
+    chgrp -Rh "$GROUP_OWNER" "$arg"
+
+    # reset ACLs recursively to make sure we don't have any non-wanted ACLs
+    setfacl -R -b "$arg"
+
+    ### Directories
+    # Set ACLs, default ACLs and setgid only for directories
+    # rwx for user, r-x for group, none for others
+    find "$arg" -type d \ 
+        -exec setfacl -m u::rwx,g::r-x,o::---,d:u::rwx,d:g::r-x,d:o::--- {} \; \
+        -exec chmod g+s {} \;
+
+    ### Files
+    # Set ACLs only for files
+    # rw- for user, r-- for group, none for others
+    find "$arg" -type f \ 
+        -exec setfacl -m u::rw${exec_perm},g::r-${exec_perm},o::--- {} \;
 }
 
 function copy_if_changed() {

--- a/infrastructure/scripts/functions.sh
+++ b/infrastructure/scripts/functions.sh
@@ -94,7 +94,7 @@ function set_perms() {
     # Set permissions to a provided file or directory.
     # Use the -x option to also set executable permissions for files.
 
-    local exec_perm arg
+    local OPTIND exec_perm arg
     
     exec_perm='-'
     while getopts ":x" opt; do

--- a/infrastructure/scripts/functions.sh
+++ b/infrastructure/scripts/functions.sh
@@ -91,15 +91,18 @@ function in_array() {
 }
 
 function set_perms() {
-    # Set permissions to a provided file or directory (recursively).
+    # Set permissions to a provided file or directory.
     # Use the -x option to also set executable permissions for files.
+    # Use the -R option to set permissions recursively.
 
-    local OPTIND exec_perm arg
+    local OPTIND OPTARG opt recursive default_exec_perm exec_perm arg
     
-    exec_perm='X' # Default to capital X to retain existing executable permissions if -x is not provided
-    while getopts ":x" opt; do
+    # Default permission to capital X, to set executable permissions to files only if any user already has executable permissions
+    default_exec_perm='X'
+    while getopts ":xR" opt; do
         case $opt in
             x) exec_perm=x ;;
+            R) recursive=true ;;
             \?) echo "Invalid option: -$OPTARG" >&2; return 1 ;;
         esac
     done
@@ -107,25 +110,28 @@ function set_perms() {
     arg="$1"
 
     # Change group owner of files and directories recursively
-    # (-h option to change symbolic links themselves and not the link they point to)
-    chgrp -Rh "$GROUP_OWNER" "$arg"
+    # we use the -h option to change symbolic links themselves and not the link they point to
+    # we use -R option if the `-R` option to this function is provided
+    chgrp ${recursive+-R} -h "$GROUP_OWNER" "$arg"
 
-    # reset ACLs recursively to make sure we don't have any non-wanted ACLs
-    setfacl -R -b "$arg"
+    # reset ACLs to make sure we don't have any non-wanted ACLs
+    # we use -R option if the `-R` option to this function is provided
+    setfacl ${recursive+-R} -b "$arg"
 
-    ### Directories
-    # Set ACLs, default ACLs and setgid only for directories
-    # rwx for user, r-x for group, none for others
-    find "$arg" -type d \
-        -exec setfacl -m u::rwx,g::r-x,o::---,d:u::rwx,d:g::r-x,d:o::--- {} \; \
-        -exec chmod g+s {} \;
-
-    ### Files
-    # Set ACLs only for files
-    # rwX for user, r-X for group, none for others (if -x option is NOT provided)
-    # rwx for user, r-x for group, none for others (if -x option is provided)
-    find "$arg" -type f \
-        -exec setfacl -m u::rw${exec_perm},g::r-${exec_perm},o::--- {} \;
+    # Set ACLs
+    acls="u::rw${exec_perm:-$default_exec_perm}" # rwx for user if -x option is provided, otherwise rwX
+    acls+=",g::r-${exec_perm:-$default_exec_perm}" # r-x for group if -x option is provided, otherwise r-X
+    acls+=",o::---" # no permissions for others
+    if [[ -d "$arg" ]]; then
+        ### Directories
+        # Add default ACLs
+        acls+=",d:u::rw-,d:g::r--,d:o::---"
+        # setgid
+        # we use -R option if the `-R` option to this function is provided
+        chmod ${recursive+-R} g+s "$arg"
+    fi
+    # we use -R option if the `-R` option to this function is provided
+    setfacl ${recursive+-R} -m "$acls" "$arg"
 }
 
 function copy_if_changed() {

--- a/infrastructure/scripts/functions.sh
+++ b/infrastructure/scripts/functions.sh
@@ -91,18 +91,17 @@ function in_array() {
 }
 
 function set_perms() {
-    # Set permissions to a provided file or directory.
-    # Use the -x option to also set executable permissions for files.
-    # Use the -R option to set permissions recursively.
+    # Set permissions to a provided file or directory (recursively).
+    # Use the -x option to set executable permissions to files.
 
-    local OPTIND OPTARG opt recursive default_exec_perm exec_perm arg
+    local OPTIND OPTARG opt default_exec_perm exec_perm arg acls
     
-    # Default permission to capital X, to set executable permissions to files only if any user already has executable permissions
+    # Default permission to capital X, to set executable permissions to files only
+    # if any user already has executable permissions
     default_exec_perm='X'
-    while getopts ":xR" opt; do
+    while getopts ":x" opt; do
         case $opt in
             x) exec_perm=x ;;
-            R) recursive=true ;;
             \?) echo "Invalid option: -$OPTARG" >&2; return 1 ;;
         esac
     done
@@ -111,27 +110,34 @@ function set_perms() {
 
     # Change group owner of files and directories recursively
     # we use the -h option to change symbolic links themselves and not the link they point to
-    # we use -R option if the `-R` option to this function is provided
-    chgrp ${recursive+-R} -h "$GROUP_OWNER" "$arg"
+    chgrp -R -h "$GROUP_OWNER" "$arg"
 
     # reset ACLs to make sure we don't have any non-wanted ACLs
-    # we use -R option if the `-R` option to this function is provided
-    setfacl ${recursive+-R} -b "$arg"
+    setfacl -R -b "$arg"
 
-    # Set ACLs
+    ### Directories
+    # Define permissions
+    acls='u::rwx' # rwx for user
+    acls+=',g::r-x' # r-x for group
+    acls+=',o::---' # no permissions for others
+    # Define default permissions
+    # (newly created files/folders within the directory will inherit these permissions)
+    acls+=',d:u::rwx' # rwx for user
+    acls+=',d:g::r-x' # r-x for group
+    acls+=',d:o::---' # no permissions for others
+    # Set permissions and setgid (newly created files/folders will inherit the group owner of the directory)
+    find "$arg" -type d \
+        -exec setfacl -m "$acls" {} + \
+        -exec chmod g+s {} +
+    
+    ### Files
+    # Define permissions
     acls="u::rw${exec_perm:-$default_exec_perm}" # rwx for user if -x option is provided, otherwise rwX
     acls+=",g::r-${exec_perm:-$default_exec_perm}" # r-x for group if -x option is provided, otherwise r-X
     acls+=",o::---" # no permissions for others
-    if [[ -d "$arg" ]]; then
-        ### Directories
-        # Add default ACLs
-        acls+=",d:u::rw-,d:g::r--,d:o::---"
-        # setgid
-        # we use -R option if the `-R` option to this function is provided
-        chmod ${recursive+-R} g+s "$arg"
-    fi
-    # we use -R option if the `-R` option to this function is provided
-    setfacl ${recursive+-R} -m "$acls" "$arg"
+    # Set permissions
+    find "$arg" -type f \
+        -exec setfacl -m "$acls" {} +
 }
 
 function copy_if_changed() {

--- a/infrastructure/scripts/functions.sh
+++ b/infrastructure/scripts/functions.sh
@@ -116,14 +116,14 @@ function set_perms() {
     ### Directories
     # Set ACLs, default ACLs and setgid only for directories
     # rwx for user, r-x for group, none for others
-    find "$arg" -type d \ 
+    find "$arg" -type d \
         -exec setfacl -m u::rwx,g::r-x,o::---,d:u::rwx,d:g::r-x,d:o::--- {} \; \
         -exec chmod g+s {} \;
 
     ### Files
     # Set ACLs only for files
     # rw- for user, r-- for group, none for others
-    find "$arg" -type f \ 
+    find "$arg" -type f \
         -exec setfacl -m u::rw${exec_perm},g::r-${exec_perm},o::--- {} \;
 }
 

--- a/infrastructure/scripts/generate_env_lock.sh
+++ b/infrastructure/scripts/generate_env_lock.sh
@@ -11,7 +11,7 @@ register_exit_trap_cmd "rm -vf $temp_env_lock_file" $TRAP_PRIORITY_LAST
 
 # Generate the environment lock file, remove the 'prefix: ...' line 
 # and set the environment name to $MODULE_NAME-$MODULE_VERSION
-"$MAMBA_EXE" env export --prefix "$TEMP_ENV_DIR" --no-rc --no-env \
+"$MAMBA_EXE" env export --prefix "$TEMP_ENV_DIR" --no-rc \
     | sed -e '/^prefix:/d' \
           -e "s|^name:.*|name: $MODULE_NAME-$MODULE_VERSION|" \
     > "$temp_env_lock_file"

--- a/infrastructure/scripts/generate_env_lock.sh
+++ b/infrastructure/scripts/generate_env_lock.sh
@@ -9,15 +9,20 @@
 temp_env_lock_file=$(mktemp)
 register_exit_trap_cmd "rm -vf $temp_env_lock_file" $TRAP_PRIORITY_LAST
 
-# Generate the environment lock file, remove the 'prefix: ...' line 
-# and set the environment name to $MODULE_NAME-$MODULE_VERSION
-"$MAMBA_EXE" env export --prefix "$TEMP_ENV_DIR" --no-rc \
-    | sed -e '/^prefix:/d' \
-          -e "s|^name:.*|name: $MODULE_NAME-$MODULE_VERSION|" \
+# Generate the environment lock file
+"$MAMBA_EXE" env export \
+    --prefix "$TEMP_ENV_DIR" \
+    --no-rc \
     > "$temp_env_lock_file"
 
-# Use awk to get pip-installed git packages from pip freeze output,
+# Remove the 'prefix: ...' line and set the environment name to $MODULE_NAME-$MODULE_VERSION
+sed -i -e '/^prefix:/d' \
+    -e "s|^name:.*|name: $MODULE_NAME-$MODULE_VERSION|" \
+    "$temp_env_lock_file"
+
+# Use awk (with 2 input files) to get pip-installed git packages from pip freeze output,
 # and then replace those in the env lock file
+# and output the final lock file to $ENV_LOCK_FILE_PATH
 awk '
 # Execute the first set of commands only for the first file (pip freeze output).
 # NR --> Total number of records processed (i.e. lines)
@@ -31,7 +36,7 @@ NR==FNR {
         gitspec = substr($0, idx+3)  # Get git specification
         specs[pkg] = gitspec # Store in specs array to use in the next set of commands
     }
-    next  # Go to next line. Do not process lines that are not match git-installed packages
+    next  # Go to next line
 }
 
 # Detect the start of the pip section in the lock file
@@ -63,4 +68,4 @@ in_pip && !/^    - / {
 
 # Print all other lines unchanged
 { print }
-' <("$TEMP_ENV_DIR/bin/python3" -m pip freeze) "$temp_env_lock_file"
+' <("$TEMP_ENV_DIR/bin/python3" -m pip freeze) "$temp_env_lock_file" > "$ENV_LOCK_FILE_PATH"

--- a/infrastructure/scripts/initialise_admin_dirs.sh
+++ b/infrastructure/scripts/initialise_admin_dirs.sh
@@ -16,8 +16,11 @@ directories=(
     "$LOGS_DIR"
 )
 
-# Create the directories and set the permissions
+# Create the directories and set the permissions only if they don't already exist
+# to avoid changing permissions on existing directories
 for dir in "${directories[@]}"; do
-    mkdir -p "$dir"
-    set_perms "$dir"
+    if [[ ! -d "$dir" ]]; then
+        mkdir -p "$dir"
+        set_perms "$dir"
+    fi
 done

--- a/infrastructure/scripts/initialise_admin_dirs.sh
+++ b/infrastructure/scripts/initialise_admin_dirs.sh
@@ -7,40 +7,8 @@ if [[ "${CONTAINERISED_ENVS_DEBUG:-0}" == "1" ]]; then
     set -x
 fi
 
-function set_admin_perms() {
-    # Set admin permissions for each of the provided arguments
-    local arg
-    for arg in "$@"; do
-        if [[ -L "$arg" ]]; then # Links
-            # Change group ownership for the link (not the file it points to)
-            chgrp -h "$GROUP_OWNER" "$arg"
-        elif [[ -d "$arg" ]]; then # Directories
-            # Change group ownership recursively
-            chgrp -R "$GROUP_OWNER" "$arg"
-            # Set group permissions recursively to match user permissions
-            # and remove all permissions for others
-            chmod -R g=u,o= "$arg"
-            # Set group ID bit, to have all children files and directories inherit the directory's group
-            chmod g+s "$arg"
-            # Set specific permissions to OWNER recursively to read, write and execute 
-            # (only if someone else already has execute) permissions, also for new files and directories.
-            # Remove all permissions for the group, to ensure only the owner has access to the admin directories and files
-            setfacl -R -m g:"$GROUP_OWNER":---,u:"$OWNER":rwX,d:g:"$GROUP_OWNER":---,d:u:"$OWNER":rwX "$arg"
-        elif [[ -f "$arg" ]]; then # Files
-            ### reset any existing acls
-            setfacl -b "$arg"
-            # Change group ownership
-            chgrp "$GROUP_OWNER" "$arg"
-            # Set group permissions to match user permissions
-            # and remove all permissions for others
-            chmod g=u,o= "$arg"
-            # Set specific permissions to OWNER to read, write and execute 
-            # (only if someone else already has execute) permissions
-            # Remove all permissions for the group, to ensure only the owner has access to the admin directories and files
-            setfacl -m g:"$GROUP_OWNER":---,u:"$OWNER":rwX "$arg"
-        fi
-    done
-}
+# Make functions available
+source "$FUNCTIONS_PATH"
 
 directories=(
     "$STABLE_PRODUCTION_BASE_DIR"
@@ -48,7 +16,8 @@ directories=(
     "$LOGS_DIR"
 )
 
+# Create the directories and set the permissions
 for dir in "${directories[@]}"; do
     mkdir -p "$dir"
-    set_admin_perms "$dir"
+    set_perms "$dir"
 done

--- a/infrastructure/scripts/install_config.sh
+++ b/infrastructure/scripts/install_config.sh
@@ -22,14 +22,8 @@ if [[ "$ENV_TYPE" != STABLE && "$ENV_TYPE" != DEVELOPMENT ]]; then
     exit 1
 fi
 
-# Path to the repository functions script
-export functions="$INFRA_SCRIPTS_DIR/functions.sh"
-if [ ! -f "$functions" ]; then
-    echo "Error! Functions file '${functions#$REPO_PATH/}' not found in the repository!" >&2
-    exit 1
-fi
 # Make functions available
-source "$functions"
+source "$FUNCTIONS_PATH"
 
 # Set BASE_DIR depending on the deployment stage and environment type:
 # - STABLE environment for PRODUCTION --> $STABLE_PRODUCTION_BASE_DIR
@@ -216,9 +210,8 @@ if [[ "$DEPLOYMENT_STAGE" == PRODUCTION ]] || [[ "$DEPLOYMENT_STAGE" == STAGING 
         mamba_temp_exe="$MAMBA_ROOT_PREFIX/micromamba"
         mamba_download_url='https://micro.mamba.pm/api/micromamba/linux-64/latest'
         curl -L "$mamba_download_url" | tar -xvjO bin/micromamba > "$mamba_temp_exe"
-        # Set executable permissions
-        chmod u+x "$mamba_temp_exe"
-        set_perms "$mamba_temp_exe"
+        # Set executable permissions to the micromamba executable
+        set_perms "$mamba_temp_exe" -x
         MAMBA_EXE="$mamba_temp_exe"
     fi
     echo "Using micromamba executable: $MAMBA_EXE"
@@ -241,9 +234,8 @@ if [[ "$DEPLOYMENT_STAGE" == PRODUCTION ]] || [[ "$DEPLOYMENT_STAGE" == STAGING 
         jq_download_url='https://github.com/jqlang/jq/releases/latest/download/jq-linux-amd64'
         echo "Installing jq's latest version:"
         curl -L "$jq_download_url" --output "$JQ_EXE"
-        # Set executable permissions
-        chmod u+x "$JQ_EXE"
-        set_perms "$JQ_EXE"
+        # Set executable permissions to the jq executable
+        set_perms "$JQ_EXE" -x
     fi
 
     ### Other settings

--- a/infrastructure/scripts/install_config.sh
+++ b/infrastructure/scripts/install_config.sh
@@ -211,7 +211,7 @@ if [[ "$DEPLOYMENT_STAGE" == PRODUCTION ]] || [[ "$DEPLOYMENT_STAGE" == STAGING 
         mamba_download_url='https://micro.mamba.pm/api/micromamba/linux-64/latest'
         curl -L "$mamba_download_url" | tar -xvjO bin/micromamba > "$mamba_temp_exe"
         # Set executable permissions to the micromamba executable
-        set_perms "$mamba_temp_exe" -x
+        set_perms -x "$mamba_temp_exe"
         MAMBA_EXE="$mamba_temp_exe"
     fi
     echo "Using micromamba executable: $MAMBA_EXE"
@@ -235,7 +235,7 @@ if [[ "$DEPLOYMENT_STAGE" == PRODUCTION ]] || [[ "$DEPLOYMENT_STAGE" == STAGING 
         echo "Installing jq's latest version:"
         curl -L "$jq_download_url" --output "$JQ_EXE"
         # Set executable permissions to the jq executable
-        set_perms "$JQ_EXE" -x
+        set_perms -x "$JQ_EXE"
     fi
 
     ### Other settings

--- a/infrastructure/scripts/write_env_exports.sh
+++ b/infrastructure/scripts/write_env_exports.sh
@@ -36,16 +36,17 @@ containerised_envs_root_dir_name=containerised_envs
 apps_dir_name=apps
 # Name of the directory where all modules will be stored
 modules_dir_name=modules
+# Path to the functions script
+functions_path="$infra_scripts_dir/functions.sh"
 
 # write export script
 cat <<EOF
-export GROUP_OWNER='$GROUP_OWNER' 
-export OWNER='$OWNER' 
-export PBS_PROJECT='$PBS_PROJECT' 
-export PBS_STORAGE='$PBS_STORAGE' 
-export SINGULARITY_EXE='$SINGULARITY_EXE' 
-export JQ_EXE='$JQ_EXE' 
-export STABLE_PRODUCTION_BASE_DIR='$STABLE_PRODUCTION_BASE_DIR' 
+export GROUP_OWNER='$GROUP_OWNER'
+export PBS_PROJECT='$PBS_PROJECT'
+export PBS_STORAGE='$PBS_STORAGE'
+export SINGULARITY_EXE='$SINGULARITY_EXE'
+export JQ_EXE='$JQ_EXE'
+export STABLE_PRODUCTION_BASE_DIR='$STABLE_PRODUCTION_BASE_DIR'
 export CONTAINERISED_ENVS_DEBUG=$CONTAINERISED_ENVS_DEBUG
 export REPO_PATH='$REPO_PATH'
 export MODULE_NAME='$MODULE_NAME'
@@ -66,4 +67,5 @@ export INSTALL_CONFIG='$install_config'
 export CONTAINERISED_ENVS_ROOT_DIR_NAME='$containerised_envs_root_dir_name'
 export APPS_DIR_NAME='$apps_dir_name'
 export MODULES_DIR_NAME='$modules_dir_name'
+export FUNCTIONS_PATH='$functions_path'
 EOF


### PR DESCRIPTION
Fixes #39
- [x] Changed `set_perms` function to set permissions according to the permissions paragraph below
- [x] Added option (`-x`) to `set_perms` to set executable permissions for files
- [x] Changed `initialise_admin_dirs.sh` to use `set_perms` as well instead of having a separate `set_admin_perms` function, as we want the same set of permissions for the admin folders 
- [x] Removed the unused `OWNER` variable

### Permissions
The following permissions have been set:

Group owner set to `$GROUP_OWNER` (defined within the GitHub Environment - i.e., HPC server)

#### Directories
- `rwx` for user
- `r-x` for group
- `---` (none) for others
- Same default permissions as above
- setgid

#### Files
- `rwX` for user
- `r-X` for group
- `---` (none) for others

If `set_perms` is run with the `-x` option, the file permission above for user and group have explicit executable permissions set (`x` instead of `X`).


> [!IMPORTANT]
> Once this PR gets merged, the `OWNER` GitHub Environment variable can be deleted from all the GitHub environments as it's not going to be used anymore.

