### PR TITLE
Add module conflicts

### DIFF
--- a/defaults/modules/modulefile
+++ b/defaults/modules/modulefile
@@ -3,6 +3,9 @@
 # The double underscore variables within this file are replaced by the 'replace_dunder_variables'
 # function within the build.sh or deploy.sh scripts
 
+# Prevent loading multiple versions of this module at the same time
+conflict __MODULE_NAME__
+
 # Prepend environment bin directory (where all launcher symlinks are located) to PATH
 prepend-path PATH "__ENV_BIN_DIR__"
 


### PR DESCRIPTION
- [x] Added conflict for loading multiple versions of the same environment at the same time


EDIT:
You can now test this by running:
```
module use /scratch/tm70/dm5220/test_containerised_envs/admin/staging/modules
module load test/20260528T141543-7a12c58-pr54
module load test/20260528T143000-7a12c58-pr54
```