### PR TITLE
Update deployment to use actual release folder on gadi

### DIFF
--- a/defaults/hpc_targets
+++ b/defaults/hpc_targets
@@ -1,1 +1,1 @@
-gadi_test
+gadi

--- a/environments/test/overrides/hpc_targets
+++ b/environments/test/overrides/hpc_targets
@@ -1,1 +1,1 @@
-test
+gadi_testing

--- a/infrastructure/scripts/write_env_exports.sh
+++ b/infrastructure/scripts/write_env_exports.sh
@@ -10,6 +10,8 @@ if [[ "${CONTAINERISED_ENVS_DEBUG:-0}" == "1" ]]; then
     set -x
 fi
 
+# Strip slash from STABLE_PRODUCTION_BASE_DIR
+STABLE_PRODUCTION_BASE_DIR=${STABLE_PRODUCTION_BASE_DIR%/}
 # Path to default files within the repository
 defaults_dir="$REPO_PATH/defaults"
 # Path to the scripts wihtin the default files


### PR DESCRIPTION
- [x] Set up `gadi` GitHub environment to be used as default HPC target. This will deploy STABLE environments to `/g/data/vk83` and DEV to `/g/data/vk83/prerelease` as the old infrastructure
- [x] Stripping of forward slash from `STABLE_PRODUCTION_BASE_DIR` variable to avoid having confusing (but still valid) double forward slashes in paths (e.g. `/g/data/vk83/prerelease//myfolder`)

> [!IMPORTANT]
> For the moment, the `test` environment was left to deploy to the `test` GitHub Environment (instead of deploying to `gadi`), which is a "testing" GitHub environment that deployes under my own folder `/scratch/tm70/dm5220/test_containerised_envs` on Gadi.
> The `test` environment is deployed whenever changes in this repo involve infrastructural files but don't touch any specific environment (for example this is the case of this PR, where the changed files don't involve any file under the `environments/` folder).
> 
> Do you think we could change the infra so that the `test` environment (i.e. infrastructural changes to test) will be deployed to `/g/data/vk83/testing`?