### PR TITLE
Add default symbolic module version only to STABLE modules

### DIFF
--- a/defaults/modules/.modulerc
+++ b/defaults/modules/.modulerc
@@ -4,7 +4,7 @@
 # function within the build.sh or deploy.sh scripts
 
 if {"__ENV_TYPE__" == "DEVELOPMENT"} {
-    module-version __MODULE_NAME__/__MODULE_VERSION__ dev
+  module-version __MODULE_NAME__/__MODULE_VERSION__ dev
+} else {
+  module-version __MODULE_NAME__/__MODULE_VERSION__ default
 }
-
-module-version __MODULE_NAME__/__MODULE_VERSION__ default


### PR DESCRIPTION
Due to clashing in the `default` symbolic version when both DEVELOPMENT and STABLE module of the same environment are loaded, the modulefile was updated to include the `default` symbolic version only for STABLE environments and the `dev` symbolic version only for DEVELOPMENT environments