### PR TITLE
Switched the word "environment" with "module" to generalise infrastructure. Updated messages

### DIFF
--- a/.github/actions/set_message/action.yml
+++ b/.github/actions/set_message/action.yml
@@ -9,10 +9,10 @@ inputs:
       The type of message to set. Can be one of:
       - summary: A message to be added to the step summary
       - pr-init: A message to be added as a comment in the PR when the deployment is initiated
-      - pr-update: A message to be added as a comment in the PR when the environment deployment ended
-      - pr-update-failure: A message to be added as a comment in the PR when the environment deployment failed
+      - pr-update: A message to be added as a comment in the PR when the deployment ends
+      - pr-update-failure: A message to be added as a comment in the PR when the deployment fails
         and no deployment information could be retrieved
-      - pr-cancelled: A message to be added as a comment in the PR when the environment deployment workflow was cancelled
+      - pr-cancelled: A message to be added as a comment in the PR when the deployment workflow was cancelled
     type: string
     required: true
   data-file:

--- a/.github/workflows/delete_all_staging_modules.yml
+++ b/.github/workflows/delete_all_staging_modules.yml
@@ -1,4 +1,4 @@
-name: Delete all the STAGING environments
+name: Delete all the STAGING modules
 description: |
   This workflow deletes the content of all STAGING directories across all available HPC targets.
 
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  # To ensure the removal of all the STAGING environments across all HPC targets, we detect all
+  # To ensure the removal of all the STAGING modules across all HPC targets, we detect all
   # available hpc targets by joining together all entries in the `hpc_targets` files (default and overrides)
   get-all-hpc-targets:
     runs-on: ubuntu-latest
@@ -30,7 +30,7 @@ jobs:
           )
           echo "all-hpc-targets=$targets" >> $GITHUB_OUTPUT
 
-  delete-staging-environments:
+  delete-staging-modules:
     needs: [get-all-hpc-targets]
     runs-on: ubuntu-latest
     strategy:
@@ -47,7 +47,7 @@ jobs:
       STABLE_PRODUCTION_BASE_DIR: '${{ vars.STABLE_PRODUCTION_BASE_DIR }}'
       MODULE_NAME: dummy_name
       MODULE_VERSION: dummy_version
-      ENV_TYPE: STABLE
+      MODULE_TYPE: STABLE
       HPC_TARGET: ${{ matrix.hpc-target }}
       STARTED_AT: dummy_date
     steps:

--- a/.github/workflows/deploy_env.yml
+++ b/.github/workflows/deploy_env.yml
@@ -151,7 +151,7 @@ jobs:
       STABLE_PRODUCTION_BASE_DIR: '${{ vars.STABLE_PRODUCTION_BASE_DIR }}'
       MODULE_NAME: '${{ inputs.environment }}'
       MODULE_VERSION: '${{ inputs.version }}'
-      ENV_TYPE: ${{ inputs.is_stable == true && 'STABLE' || 'DEVELOPMENT' }}
+      MODULE_TYPE: ${{ inputs.is_stable == true && 'STABLE' || 'DEVELOPMENT' }}
       HPC_TARGET: ${{ matrix.hpc-target }}
       STARTED_AT: ${{ needs.get-date.outputs.date }}
     steps:

--- a/.github/workflows/deploy_to_staging.yml
+++ b/.github/workflows/deploy_to_staging.yml
@@ -1,22 +1,22 @@
 name: Deploy envs to STAGING
 description: |
-  This workflow deploys environments to STAGING for Pull Requests opened to this repo 
+  This workflow deploys modules to STAGING for Pull Requests opened to this repo 
   (with `main` as a base) in the following cases: 
   
   - If the changes involve the `environments` folder, for each environment subfolder changed:
 
     - If the changes involve the `environment_dev.yml` (but not the `environment.yml`),
-      a DEVELOPMENT environment is deployed to STAGING
+      a DEVELOPMENT module is deployed to STAGING
     - If the changes involve the `environment.yml` (but not the `environment_dev.yml`),
-      a STABLE environment is deployed to STAGING
+      a STABLE module is deployed to STAGING
     - If the changes involve both the `environment_dev.yml` and `environment.yml`,
-      both a STABLE and DEVELOPMENT environment is deployed to STAGING
+      both a STABLE and DEVELOPMENT module is deployed to STAGING
     - If the changes don't involve either of the environment spec files (e.g., changes in an override file)
-      a STABLE environment is deployed to STAGING
+      a STABLE module is deployed to STAGING
 
   - If the changes don't involve the `environments` folder (for example any change to the
-    `defaults` folder), a STABLE 'test' environment is deployed to STAGING.
-    We use the 'test' environment as an example for infrastuture automatic testing within CI
+    `defaults` folder), a STABLE 'test' module is deployed to STAGING.
+    We use the 'test' module as an example for infrastuture automatic testing within CI
 
 on:
   pull_request:
@@ -57,7 +57,7 @@ jobs:
       # Since we have the built container images within the repos, and we automatically build them
       # whenever there is a change to a container definition file, we need to make sure that, if this
       # workflow is triggered by a pull request, no changes to a container definition or built image
-      # are found together with other changes, otherwise we might end up deploying an environment
+      # are found together with other changes, otherwise we might end up deploying a module
       # using a different container to the one we are supposed to be testing and deploying.
       - name: Sanity check on container-related files
         run: |
@@ -113,7 +113,7 @@ jobs:
           echo "stable_envs=$stable_envs" >> $GITHUB_OUTPUT
 
   set_version_dev:
-    name: Set version for DEVELOPMENT environments
+    name: Set version for DEVELOPMENT modules
     runs-on: ubuntu-latest
     needs: get-environments
     outputs:
@@ -131,7 +131,7 @@ jobs:
           is_stable: false
   
   set_version_stable:
-    name: Set version for STABLE environments
+    name: Set version for STABLE modules
     runs-on: ubuntu-latest
     needs: get-environments
     outputs:
@@ -149,7 +149,7 @@ jobs:
           is_stable: true
 
   deploy_development_staging:
-    name: Deploy DEVELOPMENT ${{ matrix.environment }} environment to STAGING
+    name: Deploy DEVELOPMENT ${{ matrix.environment }} module to STAGING
     needs: [get-environments, set_version_dev]
     strategy:
       fail-fast: false
@@ -158,7 +158,7 @@ jobs:
     uses: ./.github/workflows/deploy_env.yml
     with:
       environment: "${{ matrix.environment }}"
-      # We prepend `dev-` to the version of a DEVELOPMENT environment
+      # We prepend `dev-` to the version of a DEVELOPMENT module
       version: "${{ needs.set_version_dev.outputs.version }}"
       staging: true
       production: false
@@ -166,7 +166,7 @@ jobs:
     secrets: inherit
   
   deploy_stable_staging:
-    name: Deploy STABLE ${{ matrix.environment }} environment to STAGING
+    name: Deploy STABLE ${{ matrix.environment }} module to STAGING
     needs: [get-environments, set_version_stable]
     strategy:
       fail-fast: false

--- a/.github/workflows/redeploy_env.yml
+++ b/.github/workflows/redeploy_env.yml
@@ -1,8 +1,8 @@
-name: Redeploy environment to STAGING 
+name: Redeploy module to STAGING 
 description: |
   Triggered by a `!redeploy` comment on an open PR, this workflow re-runs the latest
   "Deploy envs to STAGING" (deploy_to_staging.yml) worklow for that PR. This is useful when:
-    - A development dependency was updated externally and the environment needs rebuilding,
+    - A development dependency was updated externally and the module needs rebuilding,
       but no changes were made to the PR itself
     - A transient error occurred during deployment and a retry is needed
 

--- a/.github/workflows/release_environment.yml
+++ b/.github/workflows/release_environment.yml
@@ -1,7 +1,7 @@
-name: Release STABLE environment to PRODUCTION
+name: Release STABLE module to PRODUCTION
 description: |
-  This workflow deploys STABLE environments to PRODUCTION.
-  It is used to release the environments / modules that will be used in production by the end users
+  This workflow deploys STABLE modules to PRODUCTION.
+  It is used to release the modules that will be used in production by the end users
   on the HPC systems.
 on:
   workflow_dispatch:

--- a/.github/workflows/test_message_rendering.yml
+++ b/.github/workflows/test_message_rendering.yml
@@ -75,7 +75,7 @@ jobs:
           HPC_TARGET: ${{ matrix.hpc-target }}
           MODULE_NAME: ${{ matrix.module-name }}
           MODULE_VERSION: ${{ matrix.module-version }}
-          ENV_TYPE: ${{ matrix.env-type }}
+          MODULE_TYPE: ${{ matrix.env-type }}
           STARTED_AT: "1992-04-05T23:55:00 GMT+1"
           DEPLOYMENT_STAGE: ${{ matrix.deployment-stage }}
           MODULE_USAGE_INSTRUCTIONS: "${{ matrix.success == 'true' && format('module use /path/to/other/modules\nmodule load {0}/{1}', matrix.module-name, matrix.module-version) }}"

--- a/README.md
+++ b/README.md
@@ -16,41 +16,41 @@ This GitHub
 - Some hosts directories (for example `/g` and `/scratch`) on Gadi are automatically bound to the container because of Gadi's singularity configuration file.
 - The internal Python environment is activated within the container, not when the module is loaded. When the module is loaded, only a few related env variables are set (`CONDA_PREFIX`, `CONDA_PROMPT_MODIFIER`)
 - To run in debug mode, re-run workflow enabling debug logging
-- All files are environment version specific. There are no common files used across multiple environments or environment versions. This makes each environment version completely stand-alone and not touched by any updates of the "default" infrastructure.
-- The _environment type_ (`ENV_TYPE`) can be `STABLE` or `DEVELOPMENT` (prerelease). 
-  - DEVELOPMENT envs are used to test the functionality of the development packages within the environment. The dev packages will be those installed using pip + git, for example:
+- All files are module version specific. There are no common files used across multiple modules or module versions. This makes each module version completely stand-alone and not touched by any updates of the "default" infrastructure.
+- The _module type_ (`MODULE_TYPE`) can be `STABLE` or `DEVELOPMENT` (prerelease). 
+  - DEVELOPMENT modules are used to test the functionality of the development packages within the environment they load. The dev packages will be those installed using pip + git, for example:
     ```yml
       - pip:
         - git+https://github.com/OWNER/REPO.git@REF
         - git+https://github.com/OWNER2/REPO2.git@REF2
     ```
-  - STABLE is used for non-development environments, where all packages are specified with defined versions and installed from Anaconda (preferably) or PyPI.
+  - STABLE is used for non-development modules, where the loaded environment has all packages specified with defined versions and installed from Anaconda.org (preferably).
 - The _deployment stage_ (`DEPLOYMENT_STAGE`) can be `STAGING` or `PRODUCTION`.
-  PRODUCTION environments live in the folder used by the end users.
-  STAGING environments live in a testing folder (usually not advertised to the end user).
-  STAGING environments are used for testing and validating the infrastructure (not the specific functionalities of the internal packages), mainly carried out automatically within CI. 
-  The _deployment stage_ is independent from the _environment type_.
+  PRODUCTION modules live in the folder used by the end users.
+  STAGING modules live in a testing folder (usually not advertised to the end user).
+  STAGING modules are used for testing and validating the infrastructure (not the specific functionalities of the internal packages), mainly carried out automatically within CI. 
+  The _deployment stage_ is independent from the _module type_.
 
 There can be four independent scenarios in total:
 | | **DEVELOPMENT** | **STABLE** |
 |---|---|---|
-| **STAGING** | Dev environments (git) deployed in the staging folder for infrastructural testing (through CI) | Stable environments (Anaconda/PyPI) deployed in the staging folder for infrastructural testing (through CI) |
-| **PRODUCTION** | Dev environments (git) deployed in the production folder to be tested for functionality by some users | Stable environments (Anaconda/PyPI) deployed in the production folder to be used by users in their day-to-day workflows |
+| **STAGING** | Dev modules (git) deployed in the staging folder for infrastructural testing (through CI) | Stable modules (Anaconda/PyPI) deployed in the staging folder for infrastructural testing (through CI) |
+| **PRODUCTION** | Dev modules (git) deployed in the production folder to be tested for functionality by some users | Stable modules (Anaconda/PyPI) deployed in the production folder to be used by users in their day-to-day workflows |
 
-The environments are deployed in the following scenarios:
-- DEVELOPMENT environments in PRODUCTION can be deployed as a workflow dispatch (for example if a dev package specified in `environment_dev.yml` gets updated) by providing the environment name.
+The modules are deployed in the following scenarios:
+- DEVELOPMENT modules in PRODUCTION can be deployed as a workflow dispatch (for example if a dev package specified in `environment_dev.yml` gets updated) by providing the environment name.
 - When a pull request is opened or syncronised against the `main` branch of the repo:
    - If the changes involve the `environments` folder, for each environment subfolder changed:
-       - If the changes involve the `environment_dev.yml`, a DEVELOPMENT environment in STAGING is deployed (even if there are also changes to the `environment.yml`)
-       - If the changes don't involve the `environment_dev.yml`, a STABLE environment in STAGING is deployed
-   - If the changes don't involve the `environments` folder, a `payu` STABLE environment in STAGING is deployed, only for infrastuture automatic testing.
-- When a pull request is merged to `main` (PR to main is closed with merge), if the changes involved any `environment_dev.yml` file, a DEVELOPMENT environment in PRODUCTION is deployed for each environment changed.
-- STABLE environment in PRODUCTION (the actual environment full release) can be deployed as a workflow dispatch by providing the environment name and version to be deployed.
+       - If the changes involve the `environment_dev.yml`, a DEVELOPMENT module in STAGING is deployed (even if there are also changes to the `environment.yml`)
+       - If the changes don't involve the `environment_dev.yml`, a STABLE module in STAGING is deployed
+   - If the changes don't involve the `environments` folder, a `payu` STABLE module in STAGING is deployed, only for infrastuture automatic testing.
+- When a pull request is merged to `main` (PR to main is closed with merge), if the changes involved any `environment_dev.yml` file, a DEVELOPMENT module in PRODUCTION is deployed for each environment changed.
+- STABLE module in PRODUCTION (the actual module full release) can be deployed as a workflow dispatch by providing the environment name and version to be deployed.
 
 - The disk and inodes consumption for each each env version depends on the env specification. 
-  However, an average environment version should consume around ~1GB and ~500 inodes.
+  However, an average module version should consume around ~1GB and ~500 inodes.
 
-- The `manifest.txt` is a file that keeps tracks of the files and folders created for a specific environment version. This makes deletion of a specific version easy, by running: `xargs rm -vrf < "$MANIFEST_FILE_PATH"`
+- The `manifest.txt` is a file that keeps tracks of the files and folders created for a specific module version. This makes deletion of a specific version easy (e.g., by running: `xargs rm -vrf < "$FILES_MANIFEST_PATH"`).
 
 - Changes that are needed in the host when they load the module should go in the `launcher.sh` script.
   Changes that are needed only within the container should go in the `env_activation.sh` script.
@@ -65,8 +65,8 @@ Add information on GitHub Environments setup ...
 The actual container used as the base of the environment contains only enough components to create a functional environment. The container does not contain its own operating system, instead, it is comprised of a series of empty directories and symlinks. The necessary components of Gadi’s operating systems are bind-mounted in at launch time through the launcher script. Though this does make the environment entirely unportable, which goes against the philosophy of containerisation, the container itself only needs to be constructed once for any given system, and reconstruction is trivial. The advantage of this approach is that the conda environment is separate to the container, and therefore multiple conda environments can be present ‘in’ the same container. This also means that the container can never be out of sync as Gadi’s OS receives updates. This allows us to make modifications to the conda environment after installation that enhance the functionality of the environment.
 
 ## Infrastructure
-STAGING environments are deployed within the `staging_base_dir` (set within `defaults/scripts/config.sh`).
-When a PRODUCTION environment is released, the same deployment script is run, but with base directory set to `STABLE_PRODUCTION_BASE_DIR` instead (set within `defaults/scripts/config.sh`).
+STAGING modules are deployed within the `staging_base_dir` (set within `defaults/scripts/config.sh`).
+When a PRODUCTION module is released, the same deployment script is run, but with base directory set to `STABLE_PRODUCTION_BASE_DIR` instead (set within `defaults/scripts/config.sh`).
 This allows the staging directory to have the same exact structure and files as the related production directory, so STAGING modules can be tested before being released in PRODUCTION by running the same `module load ...` commands that would be run for PRODUCTION modules.
 The only change would be the `module use ...` command, that would need to be specific to the staging directory (`staging_base_dir`).
 

--- a/defaults/modules/.modulerc
+++ b/defaults/modules/.modulerc
@@ -3,7 +3,7 @@
 # The double underscore variables within this file are replaced by the 'replace_dunder_variables'
 # function within the build.sh or deploy.sh scripts
 
-if {"__ENV_TYPE__" == "DEVELOPMENT"} {
+if {"__MODULE_TYPE__" == "DEVELOPMENT"} {
   module-version __MODULE_NAME__/__MODULE_VERSION__ dev
 } else {
   module-version __MODULE_NAME__/__MODULE_VERSION__ default

--- a/infrastructure/jinja2_templates/set_message_pr_update.j2
+++ b/infrastructure/jinja2_templates/set_message_pr_update.j2
@@ -15,34 +15,34 @@ Triggered from commit [{{ commit_sha }}]({{ commit_url }}). For further details,
 {% for hpc_target in hpc_targets %}
 ### :desktop_computer: {{ hpc_target.name }}
 
-| Environment Name | Environment Version | Environment Type | Deployment Stage | Status |
+| Module Name | Module Version | Module Type | Deployment Stage | Status |
 |---|---|---|---|---|
 {%- for deployment in hpc_target.deployments %}
-| {{ deployment.env_name }} | {{ deployment.env_version }} | {{ deployment.env_type }} | {{ deployment.deployment_stage }} | {{ ':white_check_mark:' if deployment.success == 'true' else ':x:' }} |
+| {{ deployment.module_name }} | {{ deployment.module_version }} | {{ deployment.module_type }} | {{ deployment.deployment_stage }} | {{ ':white_check_mark:' if deployment.success == 'true' else ':x:' }} |
 {%- endfor %}
 
 {% endfor %}
 
 {% if n_successful > 0 %}
 ---
-### :memo: Environment Usage Instructions
+### :memo: Module Usage Instructions
 
 {% for hpc_target in hpc_targets %}
   {% for deployment in hpc_target.deployments %}
     {% if deployment.success == 'true' %}
       {% if n_successful == 1 %}
-#### {{ deployment.env_name }}/{{ deployment.env_version }} on {{ hpc_target.name }}
+#### {{ deployment.module_name }}/{{ deployment.module_version }} on {{ hpc_target.name }}
 
 ```
-{{ deployment.env_usage_instructions }}
+{{ deployment.module_usage_instructions }}
 ```
 
       {% else %}
 <details>
-<summary><b>{{ deployment.env_name }}/{{ deployment.env_version }} on {{ hpc_target.name }}</b></summary>
+<summary><b>{{ deployment.module_name }}/{{ deployment.module_version }} on {{ hpc_target.name }}</b></summary>
 
 ```
-{{ deployment.env_usage_instructions }}
+{{ deployment.module_usage_instructions }}
 ```
 
 </details>

--- a/infrastructure/jinja2_templates/set_message_pr_update_failure.j2
+++ b/infrastructure/jinja2_templates/set_message_pr_update_failure.j2
@@ -1,7 +1,6 @@
 ## :x: Deployments Failed
 
-The deployments triggered from commit [{{ commit_sha }}]({{ commit_url }}) failed, but there were
-problems retrieving information about specific deployments.
+Deployments triggered from commit [{{ commit_sha }}]({{ commit_url }}) failed, but deployment details could not be retrieved.
 
 For further details, check the [workflow run]({{ workflow_url }}).
 

--- a/infrastructure/jinja2_templates/set_message_summary.j2
+++ b/infrastructure/jinja2_templates/set_message_summary.j2
@@ -1,17 +1,18 @@
 {% for deployment in deployments %}
-## :rocket: Deployed _{{ deployment.env_name }}_ environment on :desktop_computer: {{ name }}
+## :rocket: Deployed _{{ deployment.module_name }}_ module on :desktop_computer: {{ name }}
 
 **HPC Target:** {{ name }}
-**Environment Name:** {{ deployment.env_name }}
-**Environment Version:** {{ deployment.env_version }}
-**Environment Type:** {{ deployment.env_type }}
+**Module Name:** {{ deployment.module_name }}
+**Module Version:** {{ deployment.module_version }}
+**Module Type:** {{ deployment.module_type }}
 **Deployment Stage:** {{ deployment.deployment_stage }}
 
-To use the environment on _{{ name }}_, run the following commands:
+To use the module on _{{ name }}_, run the following commands:
 ```
-{{ deployment.env_usage_instructions }}
+{{ deployment.module_usage_instructions }}
 ```
 
+{% if deployment.env_lock %}
 <details>
 <summary><b>Environment lock</b></summary>
 
@@ -20,5 +21,5 @@ To use the environment on _{{ name }}_, run the following commands:
 ```
 
 </details>
-
+{% endif %}
 {% endfor %}

--- a/infrastructure/json_schemas/hpc_target_deployment_info.schema.json
+++ b/infrastructure/json_schemas/hpc_target_deployment_info.schema.json
@@ -15,11 +15,11 @@
       "items": {
         "type": "object",
         "required": [
-            "env_name", 
-            "env_version", 
-            "env_type", 
+            "module_name", 
+            "module_version", 
+            "module_type", 
             "deployment_stage", 
-            "env_usage_instructions", 
+            "module_usage_instructions", 
             "env_lock",
             "started_at",
             "completed_at",
@@ -27,9 +27,9 @@
         ],
         "additionalProperties": false,
         "properties": {
-          "env_name": { "type": "string", "minLength": 1 },
-          "env_version": { "type": "string", "minLength": 1 },
-          "env_type": {
+          "module_name": { "type": "string", "minLength": 1 },
+          "module_version": { "type": "string", "minLength": 1 },
+          "module_type": {
             "type": "string",
             "enum": ["DEVELOPMENT", "STABLE"]
           },
@@ -37,7 +37,7 @@
             "type": "string",
             "enum": ["STAGING", "PRODUCTION"]
           },
-          "env_usage_instructions": { "type": "string" },
+          "module_usage_instructions": { "type": "string" },
           "env_lock": { "type": "string" },
           "started_at": { "type": "string", "minLength": 1 },
           "completed_at": { "type": "string" },

--- a/infrastructure/scripts/build_and_deploy_env.sh
+++ b/infrastructure/scripts/build_and_deploy_env.sh
@@ -21,24 +21,24 @@ exec &> "$PBS_JOB_LOG_FILE"
 source "$INSTALL_CONFIG"
 
 ### Initialise directories
-# Make sure the target environment directory does not already exist, to avoid accidentally overwriting an existing environment.
-if [[ -d "$ENV_VERSION_DIR" ]]; then
-    echo "Error! Environment version '$MODULE_NAME/$MODULE_VERSION' already exists." >&2
+# Make sure the target module directory does not already exist, to avoid accidentally overwriting an existing environment.
+if [[ -d "$APP_VERSION_DIR" ]]; then
+    echo "Error! Module version '$MODULE_NAME/$MODULE_VERSION' already exists." >&2
     exit 1
 fi
-# Create a trap function that would delete the environment version related files
+# Create a trap function that would delete the module version related files
 # in case the script fails
 cleanup_env() {
     # _exit_status vaiable is initialised within the register_exit_trap_cmd function
     if [ $_exit_status -ne 0 ]; then
-        echo "Error! Build failed. Cleaning up environment version '$MODULE_NAME/$MODULE_VERSION' related files..." >&2
+        echo "Error! Build failed. Cleaning up module version '$MODULE_NAME/$MODULE_VERSION' related files..." >&2
         delete_files_in_manifest
     fi
 }
 register_exit_trap_cmd cleanup_env $TRAP_PRIORITY_LAST
 
 echo 'Initialising directories...'
-mkdir -pv "$ENV_VERSION_DIR"
+mkdir -pv "$APP_VERSION_DIR"
 mkdir -pv "$MODULE_DIR"
 mkdir -pv "$ENV_BIN_DIR"
 mkdir -pv "$(dirname "$TEMP_ENV_DIR")"
@@ -56,15 +56,15 @@ register_exit_trap_cmd update_hpc_target_deployment_info $TRAP_PRIORITY_FIRST
 
 
 ### CREATE MANIFEST FILE
-# Create a manifest file listing all the files and folders related to the current environment version:
+# Create a manifest file listing all the files and folders related to the current module version:
 # - Modulefile
 # - Env activation file
 # - Env folder
 
-cat > "$MANIFEST_FILE_PATH" <<EOF
+cat > "$FILES_MANIFEST_PATH" <<EOF
 $MODULE_FILE_PATH
 $ACTIVATION_SCRIPT_PATH
-$ENV_VERSION_DIR
+$APP_VERSION_DIR
 EOF
 
 ### UPDATE CONTAINER IMAGE
@@ -229,8 +229,8 @@ echo "Environment lock created to: '$ENV_LOCK_FILE_PATH'"
 ### CLEANUP OLDEST DEVELOPMENT ENV FOR PRODUCTION
 source "$INFRA_SCRIPTS_DIR/cleanup_old_dev_env.sh"
 
-### ENSURE RIGHT PERMISSIONS RECURSIVELY FOR ENVIRONMENT VERSION
-set_perms "$ENV_VERSION_DIR"
+### ENSURE RIGHT PERMISSIONS RECURSIVELY FOR MODULE VERSION
+set_perms "$APP_VERSION_DIR"
 
 ### EXPORT ENV VARIABLES FOR HPC TARGET DEPLOYMENT INFO JSON (update_hpc_target_deployment_info trap function)
 # MODULE_USAGE_INSTRUCTIONS

--- a/infrastructure/scripts/cleanup_old_dev_env.sh
+++ b/infrastructure/scripts/cleanup_old_dev_env.sh
@@ -1,21 +1,21 @@
 # This file is sourced in the build_and_deploy_env.sh script to cleanup oldest DEVELOPMENT
-# environments for PRODUCTION if the number of dev env versions is greater than MAX_DEV_ENV_VERSIONS
+# modules for PRODUCTION if the number of dev env versions is greater than MAX_DEV_MODULE_VERSIONS
 
 # Only for DEVELOPMENT envs in PRODUCTION
-if [[ "$ENV_TYPE" == DEVELOPMENT ]] && [[ "$DEPLOYMENT_STAGE" == PRODUCTION ]]; then
-    env_versions=$(
-        find "$ENV_DIR" \
+if [[ "$MODULE_TYPE" == DEVELOPMENT ]] && [[ "$DEPLOYMENT_STAGE" == PRODUCTION ]]; then
+    module_versions=$(
+        find "$APP_DIR" \
         -mindepth 1 -maxdepth 1 \
         -type d \
         -printf '%T+ %p\n' \
         | sort
     )
-    num_versions=$(echo "$env_versions" | wc -l)
-    if [[ $num_versions -gt $MAX_DEV_ENV_VERSIONS ]]; then
-        oldest_version_dir=$(echo "$env_versions" | head -n 1 | cut -d' ' -f2-)
-        oldest_version_manifest="$oldest_version_dir/$MANIFEST_FILE_NAME"
+    num_versions=$(echo "$module_versions" | wc -l)
+    if [[ $num_versions -gt $MAX_DEV_MODULE_VERSIONS ]]; then
+        oldest_version_dir=$(echo "$module_versions" | head -n 1 | cut -d' ' -f2-)
+        oldest_version_manifest="$oldest_version_dir/$FILES_MANIFEST_NAME"
         oldest_version=$(basename "$oldest_version_dir")
-        msg="Number of '$MODULE_NAME' DEVELOPMENT versions in PRODUCTION greater than '$MAX_DEV_ENV_VERSIONS'. "
+        msg="Number of '$MODULE_NAME' DEVELOPMENT versions in PRODUCTION greater than '$MAX_DEV_MODULE_VERSIONS'. "
         msg+="Cleaning up oldest '$MODULE_NAME' DEVELOPMENT version: $oldest_version"
         echo "$msg"
         delete_files_in_manifest "$oldest_version_manifest"

--- a/infrastructure/scripts/create_hpc_target_deployment_info_json.sh
+++ b/infrastructure/scripts/create_hpc_target_deployment_info_json.sh
@@ -5,7 +5,7 @@
 # - HPC_TARGET
 # - MODULE_NAME
 # - MODULE_VERSION
-# - ENV_TYPE
+# - MODULE_TYPE
 # - DEPLOYMENT_STAGE
 # - STARTED_AT
 # - MODULE_USAGE_INSTRUCTIONS
@@ -28,24 +28,24 @@ date=$(TZ='Australia/Sydney' date '+%FT%T %Z')
     --arg target "$HPC_TARGET" \
     --arg name "$MODULE_NAME" \
     --arg version "$MODULE_VERSION" \
-    --arg type "$ENV_TYPE" \
+    --arg type "$MODULE_TYPE" \
     --arg stage "$DEPLOYMENT_STAGE" \
     --arg started_at "$STARTED_AT" \
     --arg completed_at "$date" \
-    --arg env_usage_instructions "${MODULE_USAGE_INSTRUCTIONS:-}" \
+    --arg module_usage_instructions "${MODULE_USAGE_INSTRUCTIONS:-}" \
     --arg env_lock "${ENV_LOCK:-}" \
     --arg success "$SUCCESS" \
     '{
         "name": $target,
         "deployments": [
             {
-                "env_name": $name,
-                "env_version": $version,
-                "env_type": $type,
+                "module_name": $name,
+                "module_version": $version,
+                "module_type": $type,
                 "deployment_stage": $stage,
                 "started_at": $started_at,
                 "completed_at": $completed_at,
-                "env_usage_instructions": $env_usage_instructions,
+                "module_usage_instructions": $module_usage_instructions,
                 "env_lock": $env_lock,
                 "success": $success
             }

--- a/infrastructure/scripts/delete_staging_files.sh
+++ b/infrastructure/scripts/delete_staging_files.sh
@@ -1,16 +1,16 @@
 #!/usr/bin/env bash
 
-# This script is used to delete the staging files associated to a STAGING environment deployment.
+# This script is used to delete the staging files associated to a STAGING module deployment.
 
 # Usage: delete_staging_files.sh [<pr_number> | --all]
 
 # There are three deletion cases:
 # 1. PRODUCTION env deployed through a workflow dispatch.
-#    In this case, there is only one staging environment deployed and it can be identified through
+#    In this case, there is only one staging module deployed and it can be identified through
 #    the $MODULE_VERSION variable (this script doesn't need any additional parameters).
 # 2. STAGING envs deployment within a Pull Request.
-#    In this case, there can be multiple environments deployed within the same PR
-#    (this script needs the pr_number positional parameter to identify all the environments associated with that PR).
+#    In this case, there can be multiple modules deployed within the same PR
+#    (this script needs the pr_number positional parameter to identify all the modules associated with that PR).
 # 3. All STAGING envs deployment.
 #    In this case, all files in the staging directories (STABLE and DEVELOPMENT) will be deleted.
 #    (this script needs the --all flag).
@@ -54,14 +54,14 @@ else
     pr_number="$1"
     # Pr number is provided: delete all files associated with that pr_number
     # Define regex to find all manifests of env versions associated with the pr_number
-    regex=".*/.*-pr${pr_number}[^0-9]*/${MANIFEST_FILE_NAME}$"
-    # We need to find both DEVELOPMENT and STABLE environments.
-    # The DEVELOPMENT environment directory is ENV_DIR (because we run this within a workflow without
+    regex=".*/.*-pr${pr_number}[^0-9]*/${FILES_MANIFEST_NAME}$"
+    # We need to find both DEVELOPMENT and STABLE modules.
+    # The DEVELOPMENT module directory is APP_DIR (because we run this within a workflow without
     # is_stable and its default value is false)
-    # The STABLE environment directory is derived from ENV_DIR by removing the DEVELOPMENT_STAGING_BASE_DIR
+    # The STABLE module directory is derived from APP_DIR by removing the DEVELOPMENT_STAGING_BASE_DIR
     # prefix and adding the STABLE_STAGING_BASE_DIR prefix instead.
-    development_env_dir="$ENV_DIR"
-    stable_env_dir="$STABLE_STAGING_BASE_DIR/${ENV_DIR#$DEVELOPMENT_STAGING_BASE_DIR/}"
+    development_env_dir="$APP_DIR"
+    stable_env_dir="$STABLE_STAGING_BASE_DIR/${APP_DIR#$DEVELOPMENT_STAGING_BASE_DIR/}"
     # Only add directories if they exist, otherwise the find command below would fail
     dirs=()
     if [[ -d "$development_env_dir" ]]; then

--- a/infrastructure/scripts/functions.sh
+++ b/infrastructure/scripts/functions.sh
@@ -68,8 +68,8 @@ function register_exit_trap_cmd() {
 
 function delete_files_in_manifest() {
     # Delete all files and folders associated with a version, which are listed in the manifest $1.
-    # If $1 is not provided, it defaults to the MANIFEST_FILE_PATH for the current environment version.
-    local manifest_file="${1:-$MANIFEST_FILE_PATH}"
+    # If $1 is not provided, it defaults to the FILES_MANIFEST_PATH for the current module version.
+    local manifest_file="${1:-$FILES_MANIFEST_PATH}"
     if [[ ! -f "$manifest_file" ]]; then
         echo "Error: manifest file '$manifest_file' not found." >&2
         return 1

--- a/infrastructure/scripts/install_config.sh
+++ b/infrastructure/scripts/install_config.sh
@@ -16,35 +16,35 @@ export TRAP_PRIORITY_LAST=90 # Runs last (e.g. used for commands that delete fil
 # Set the default DEPLOYMENT_STAGE
 DEPLOYMENT_STAGE=${DEPLOYMENT_STAGE:-}
 
-# Sanity check on ENV_TYPE
-if [[ "$ENV_TYPE" != STABLE && "$ENV_TYPE" != DEVELOPMENT ]]; then
-    echo "Error: Invalid ENV_TYPE '$ENV_TYPE'. Must be either 'STABLE' or 'DEVELOPMENT'." >&2
+# Sanity check on MODULE_TYPE
+if [[ "$MODULE_TYPE" != STABLE && "$MODULE_TYPE" != DEVELOPMENT ]]; then
+    echo "Error: Invalid MODULE_TYPE '$MODULE_TYPE'. Must be either 'STABLE' or 'DEVELOPMENT'." >&2
     exit 1
 fi
 
 # Make functions available
 source "$FUNCTIONS_PATH"
 
-# Set BASE_DIR depending on the deployment stage and environment type:
-# - STABLE environment for PRODUCTION --> $STABLE_PRODUCTION_BASE_DIR
-# - STABLE environment for STAGING --> $STABLE_STAGING_BASE_DIR
-# - DEVELOPMENT environment for PRODUCTION --> $DEVELOPMENT_PRODUCTION_BASE_DIR
-# - DEVELOPMENT environment for STAGING --> $DEVELOPMENT_STAGING_BASE_DIR
+# Set BASE_DIR depending on the deployment stage and module type:
+# - STABLE module for PRODUCTION --> $STABLE_PRODUCTION_BASE_DIR
+# - STABLE module for STAGING --> $STABLE_STAGING_BASE_DIR
+# - DEVELOPMENT module for PRODUCTION --> $DEVELOPMENT_PRODUCTION_BASE_DIR
+# - DEVELOPMENT module for STAGING --> $DEVELOPMENT_STAGING_BASE_DIR
 
-if [[ "$ENV_TYPE" == DEVELOPMENT ]]; then
+if [[ "$MODULE_TYPE" == DEVELOPMENT ]]; then
     if [[ "$DEPLOYMENT_STAGE" == PRODUCTION ]]; then
-        # DEVELOPMENT environment deployed to PRODUCTION
+        # DEVELOPMENT module deployed to PRODUCTION
         BASE_DIR="$DEVELOPMENT_PRODUCTION_BASE_DIR"
     else
-        # DEVELOPMENT environment deployed to STAGING 
+        # DEVELOPMENT module deployed to STAGING 
         # Or cases where no deployment takes place (e.g., staging files deletion)
         BASE_DIR="$DEVELOPMENT_STAGING_BASE_DIR"
     fi
 elif [[ "$DEPLOYMENT_STAGE" == PRODUCTION ]]; then
-    # STABLE environment deployed to PRODUCTION
+    # STABLE module deployed to PRODUCTION
     BASE_DIR="$STABLE_PRODUCTION_BASE_DIR"
 else
-    # STABLE environment deployed to STAGING
+    # STABLE module deployed to STAGING
     # Or cases where no deployment takes place (e.g., staging files deletion)
     BASE_DIR="$STABLE_STAGING_BASE_DIR"
 fi
@@ -57,14 +57,14 @@ export APPS_DIR="$BASE_DIR/$APPS_DIR_NAME"
 # management/creation, as well as configuration and files for each different 
 # existing environment
 containerised_envs_root_dir="$APPS_DIR/$CONTAINERISED_ENVS_ROOT_DIR_NAME"
-# Path to the directory containing all versions of the containerised environment
-export ENV_DIR="$containerised_envs_root_dir/envs/$MODULE_NAME"
-# Path to the directory containing the containerised environment specific version
-export ENV_VERSION_DIR="$ENV_DIR/$MODULE_VERSION"
-# Manifest file name for easy env version deletion
-export MANIFEST_FILE_NAME=manifest.txt
-# Manifest file for easy env version deletion
-export MANIFEST_FILE_PATH="$ENV_VERSION_DIR/$MANIFEST_FILE_NAME"
+# Path to the directory containing all versions of the app
+export APP_DIR="$containerised_envs_root_dir/envs/$MODULE_NAME"
+# Path to the directory containing the specific version of the app
+export APP_VERSION_DIR="$APP_DIR/$MODULE_VERSION"
+# Files manifest name for easy module version deletion
+export FILES_MANIFEST_NAME=files_manifest.txt
+# Files manifest for easy module version deletion
+export FILES_MANIFEST_PATH="$APP_VERSION_DIR/$FILES_MANIFEST_NAME"
 
 ### Logic that runs only if a deployment is taking place
 if [[ "$DEPLOYMENT_STAGE" == PRODUCTION ]] || [[ "$DEPLOYMENT_STAGE" == STAGING ]]; then
@@ -132,7 +132,7 @@ if [[ "$DEPLOYMENT_STAGE" == PRODUCTION ]] || [[ "$DEPLOYMENT_STAGE" == STAGING 
 
 
     # Path to the bin directory where all the containerised environment binaries are stored
-    export ENV_BIN_DIR="$ENV_VERSION_DIR/bin"
+    export ENV_BIN_DIR="$APP_VERSION_DIR/bin"
 
     # Set launcher script name
     export LAUNCHER_SCRIPT_NAME=launcher.sh
@@ -148,28 +148,28 @@ if [[ "$DEPLOYMENT_STAGE" == PRODUCTION ]] || [[ "$DEPLOYMENT_STAGE" == STAGING 
     # This image is automatically built by the build_container_image.yml workflow
     export REPO_CONTAINER_IMAGE_PATH="$DEFAULTS_DIR/container/base_image.sif"
     # Path to the container image to be used at runtime
-    export RUNTIME_CONTAINER_IMAGE_PATH="$ENV_VERSION_DIR/$(basename "$REPO_CONTAINER_IMAGE_PATH")"
+    export RUNTIME_CONTAINER_IMAGE_PATH="$APP_VERSION_DIR/$(basename "$REPO_CONTAINER_IMAGE_PATH")"
 
     # Name of the created squashfs file
     export SQSH_FILENAME=overlay.sqsh
     # Full path to the created squashfs file in the temporary directory
     export TEMP_SQSH_FILE_PATH="$TEMP_WORKING_DIR/$SQSH_FILENAME"
     # Full path to the squashfs file
-    export SQSH_FILE_PATH="$ENV_VERSION_DIR/$SQSH_FILENAME"
+    export SQSH_FILE_PATH="$APP_VERSION_DIR/$SQSH_FILENAME"
 
 
     # Name of the environment lock file
     env_lock_filename=env_spec_lock.yml
     # Full path to the environment lock file
-    export ENV_LOCK_FILE_PATH="$ENV_VERSION_DIR/$env_lock_filename"
+    export ENV_LOCK_FILE_PATH="$APP_VERSION_DIR/$env_lock_filename"
     # Environment specification file
     if [[ "$DEPLOYMENT_STAGE" == PRODUCTION ]]; then
         # If the deployment is for PRODUCTION, use the specification lock file produced in the STAGING deployment
-        if [[ "$ENV_TYPE" == STABLE ]]; then
-            # For a STABLE env, take the ENV_LOCK_FILE_PATH and replace the initial BASE_DIR with the STABLE_STAGING_BASE_DIR
+        if [[ "$MODULE_TYPE" == STABLE ]]; then
+            # For a STABLE module, take the ENV_LOCK_FILE_PATH and replace the initial BASE_DIR with the STABLE_STAGING_BASE_DIR
             env_spec_path=$STABLE_STAGING_BASE_DIR/${ENV_LOCK_FILE_PATH#$BASE_DIR/}
         else
-            # For a DEVELOPMENT env, take the ENV_LOCK_FILE_PATH and replace the initial BASE_DIR with the DEVELOPMENT_STAGING_BASE_DIR
+            # For a DEVELOPMENT module, take the ENV_LOCK_FILE_PATH and replace the initial BASE_DIR with the DEVELOPMENT_STAGING_BASE_DIR
             env_spec_path=$DEVELOPMENT_STAGING_BASE_DIR/${ENV_LOCK_FILE_PATH#$BASE_DIR/}
         fi
         if [ ! -f "$env_spec_path" ]; then
@@ -178,11 +178,11 @@ if [[ "$DEPLOYMENT_STAGE" == PRODUCTION ]] || [[ "$DEPLOYMENT_STAGE" == STAGING 
         fi
     else
         # If the deployment is for STAGING, use the specification from the repository
-        if [[ "$ENV_TYPE" == STABLE ]]; then
-            # 'environment.yml' for STABLE environments
+        if [[ "$MODULE_TYPE" == STABLE ]]; then
+            # 'environment.yml' for STABLE modules
             env_spec_path="$env_folder/environment.yml"
         else
-            #' environment_dev.yml' for DEVELOPMENT environments
+            #' environment_dev.yml' for DEVELOPMENT modules
             env_spec_path="$env_folder/environment_dev.yml"
         fi
         if [ ! -f "$env_spec_path" ]; then
@@ -192,9 +192,9 @@ if [[ "$DEPLOYMENT_STAGE" == PRODUCTION ]] || [[ "$DEPLOYMENT_STAGE" == STAGING 
     fi
     export ENV_FILE="$env_spec_path"
 
-    # Maximum number of DEVELOPMENT environment versions to keep in PRODUCTION simultaneously.
+    # Maximum number of DEVELOPMENT module versions to keep in PRODUCTION simultaneously.
     # If a new deployment causes the total to exceed this limit, the oldest version is deleted.
-    export MAX_DEV_ENV_VERSIONS=3
+    export MAX_DEV_MODULE_VERSIONS=3
 
     ### Micromamba initialisation
     export MAMBA_EXE="${MAMBA_EXE:-}"
@@ -229,7 +229,7 @@ if [[ "$DEPLOYMENT_STAGE" == PRODUCTION ]] || [[ "$DEPLOYMENT_STAGE" == STAGING 
         else
             echo "jq executable '$JQ_EXE' is not executable."
         fi
-        # Set JQ_EXE within the environment temporary directory TEMP_WORKING_DIR
+        # Set JQ_EXE within the temporary directory TEMP_WORKING_DIR
         JQ_EXE="$TEMP_WORKING_DIR/jq"
         jq_download_url='https://github.com/jqlang/jq/releases/latest/download/jq-linux-amd64'
         echo "Installing jq's latest version:"

--- a/infrastructure/scripts/write_env_exports.sh
+++ b/infrastructure/scripts/write_env_exports.sh
@@ -22,11 +22,11 @@ infra_scripts_dir="$REPO_PATH/infrastructure/scripts"
 admin_dir="$STABLE_PRODUCTION_BASE_DIR/admin"
 # Name of the development subdirectory
 development_subdir_name=prerelease
-# Path to the directory where development environments for production are deployed
+# Path to the directory where development modules for production are deployed
 development_production_base_dir="$STABLE_PRODUCTION_BASE_DIR/$development_subdir_name"
-# Path to the directory where stable environments for staging are deployed
+# Path to the directory where stable modules for staging are deployed
 stable_staging_base_dir="$admin_dir/staging"
-# Path to the directory where development environments for staging are deployed
+# Path to the directory where development modules for staging are deployed
 development_staging_base_dir="$admin_dir/staging/$development_subdir_name"
 # Path to the logs directory
 logs_dir="$admin_dir/logs"
@@ -53,7 +53,7 @@ export CONTAINERISED_ENVS_DEBUG=$CONTAINERISED_ENVS_DEBUG
 export REPO_PATH='$REPO_PATH'
 export MODULE_NAME='$MODULE_NAME'
 export MODULE_VERSION='$MODULE_VERSION'
-export ENV_TYPE='$ENV_TYPE'
+export MODULE_TYPE='$MODULE_TYPE'
 export HPC_TARGET='$HPC_TARGET'
 export HPC_TARGET_DEPLOYMENT_INFO_JSON_PATH='$HPC_TARGET_DEPLOYMENT_INFO_JSON_PATH'
 export STARTED_AT='$STARTED_AT'


### PR DESCRIPTION
To make the infrastructure more general and usable by other repositories, some occurrencies of the word "environment" (environments, env, and similar) have been changed to `module` or `app`.