### PR TITLE
Fixed env activation script

### DIFF
--- a/defaults/scripts/env_activation.sh
+++ b/defaults/scripts/env_activation.sh
@@ -14,7 +14,7 @@ export CONDA_DEFAULT_ENV="$env_path"
 export CONDA_PREFIX="$env_path"
 export CONDA_PROMPT_MODIFIER="__ENV_PROMPT_MODIFIER__"
 
-for file in "$env_path"/conda/activate.d/*.sh; do
+for file in "$env_path"/etc/conda/activate.d/*.sh; do
     if [ -r "$file" ]; then
         . "$file"
     fi

--- a/environments/payu/overrides/scripts/env_activation.sh
+++ b/environments/payu/overrides/scripts/env_activation.sh
@@ -16,7 +16,7 @@ export CONDA_PROMPT_MODIFIER="__ENV_PROMPT_MODIFIER__"
 # Payu specific environment variables
 export ENV_LAUNCHER_SCRIPT_PATH="__LAUNCHER_SCRIPT_PATH__"
 
-for file in "$env_path"/conda/activate.d/*.sh; do
+for file in "$env_path"/etc/conda/activate.d/*.sh; do
     if [ -r "$file" ]; then
         . "$file"
     fi


### PR DESCRIPTION
The environment activation script `env_activation.sh` mistakenly looped through the activation scripts within the internal conda environment using `<internal_env_path>/conda/activate.d/*.sh`. 
This path was wrong and has been changed to the correct `<internal_env_path>/etc/conda/activate.d/*.` (note additional `etc` subfolder).
