### PR TITLE
Fix dev deployments deleting the production environment

### DIFF
--- a/.github/workflows/deploy_env.yml
+++ b/.github/workflows/deploy_env.yml
@@ -268,6 +268,7 @@ jobs:
             fi
             # Set configuration environment
             source '$REPO_PATH/$ENV_CONFIG_FILENAME'
+            export DEPLOYMENT_STAGE=STAGING
             # Delete staging files
             "\$INFRA_SCRIPTS_DIR/delete_staging_files.sh" ${{ github.event.number }}
           EOT

--- a/infrastructure/scripts/install_config.sh
+++ b/infrastructure/scripts/install_config.sh
@@ -34,16 +34,16 @@ export DEVELOPMENT_STAGING_BASE_DIR="$STABLE_PRODUCTION_BASE_DIR/$development_su
 
 # Set base directory depending on the module type:
 if [[ "$MODULE_TYPE" == DEVELOPMENT ]]; then
-    if [[ "$DEPLOYMENT_STAGE" == STAGING ]]; then
-        base_dir="$DEVELOPMENT_STAGING_BASE_DIR"
-    else
+    if [[ "$DEPLOYMENT_STAGE" == PRODUCTION ]]; then
         base_dir="$DEVELOPMENT_PRODUCTION_BASE_DIR"
+    else
+        base_dir="$DEVELOPMENT_STAGING_BASE_DIR"
     fi
 else
-    if [[ "$DEPLOYMENT_STAGE" == STAGING ]]; then
-        base_dir="$STABLE_STAGING_BASE_DIR"
-    else
+    if [[ "$DEPLOYMENT_STAGE" == PRODUCTION ]]; then
         base_dir="$STABLE_PRODUCTION_BASE_DIR"
+    else
+        base_dir="$STABLE_STAGING_BASE_DIR"
     fi
 fi
 export BASE_DIR="$base_dir"

--- a/infrastructure/scripts/install_config.sh
+++ b/infrastructure/scripts/install_config.sh
@@ -13,8 +13,11 @@ fi
 export TRAP_PRIORITY_FIRST=10 # Runs first (Used for setup commands)
 export TRAP_PRIORITY_LAST=90 # Runs last (e.g. used for commands that delete files/folders)
 
-# Set the default DEPLOYMENT_STAGE
-DEPLOYMENT_STAGE=${DEPLOYMENT_STAGE:-}
+# Sanity check on DEPLOYMENT_STAGE
+if [[ "$DEPLOYMENT_STAGE" != STAGING && "$DEPLOYMENT_STAGE" != PRODUCTION ]]; then
+    echo "Error: Invalid DEPLOYMENT_STAGE '$DEPLOYMENT_STAGE'. Must be either 'STAGING' or 'PRODUCTION'." >&2
+    exit 1
+fi
 
 # Sanity check on MODULE_TYPE
 if [[ "$MODULE_TYPE" != STABLE && "$MODULE_TYPE" != DEVELOPMENT ]]; then


### PR DESCRIPTION
Default BASE_DIR setting to a staging directory (rather than a production directory), and explicitly set `DEPLOYMENT_STAGE` when deleting staging environments in `deploy_env.yml`. 

This should hopefully fix the issue in the following workflow that deletes the production environment (rather than the staging environment): https://github.com/ACCESS-NRI/containerised-environments-infra/actions/runs/28342734867
(The logs had DEPLOYMENT_STAGE="")


Related to https://github.com/ACCESS-NRI/containerised-environments-infra/pull/71