### PR TITLE
Add r-meorg environment

### DIFF
--- a/environments/r-meorg/environment.yml
+++ b/environments/r-meorg/environment.yml
@@ -1,0 +1,7 @@
+name: palsr
+channels:
+  - me-org
+  - conda-forge
+  - nodefaults
+dependencies:
+  - me-org::r-meorg==1.0.4

--- a/environments/r-meorg/environment.yml
+++ b/environments/r-meorg/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - nodefaults
 dependencies:
-  - me-org::r-meorg==1.0.4
+  - me-org::r-meorg==1.0.5


### PR DESCRIPTION
Added STABLE environment specification for the new `r-meorg` environment.
The DEVELOPMENT environment will not be added for the moment, for reasons mentioned in issue #51.

From the specification drafted [here](https://github.com/ACCESS-NRI/containerised-environments-infra/issues/51#issuecomment-4552052573) I did not include any package, but only the new `r-meorg 1.0.4` package because:

- `r-base`, `make`, `libnetcdf`, `hdf5`, `r-ncdf4`, `r-rjsonio`, `r-plotrix`, `r-colorramps`, `r-colorspace`, `r-scales` will be installed automatically with the `r-meorg` package;
- `r-devel`, `compilers`, `z-lib` might not be needed in the STABLE `r-meorg` environment

Please let me know if you would like the environment specification modified after testing the `r-meorg` STAGING environment deployed from this PR.

FYI @bschroeter @yuvrajsingh2

> [!IMPORTANT]
> To be able to test the environments, you need to be a member of `vk83` on Gadi