### PR TITLE
General restructuring

### DIFF
--- a/.github/actions/set_up_hpc_target/action.yml
+++ b/.github/actions/set_up_hpc_target/action.yml
@@ -9,12 +9,14 @@ description: |
     to have the CI environment ready within the HPC system.
   - Sync repository to the HPC target
 
-  This action exports the following environment variables that can be used in subsequent steps:
-  - REPO_PATH: the path to this repository synced on the HPC target
-  - HPC_TARGET_DEPLOYMENT_INFO_JSON_PATH: the path to the hpc_target_deployment_info.json file on the HPC target
-  - HPC_TARGET_DEPLOYMENT_INFO_JSON_PATH_ON_GITHUB_RUNNER: the path to the hpc_target_deployment_info.json file on the GitHub runner
-  - ENV_CONFIG_FILENAME: the name of the environment configuration script that can be sourced to have the CI environment ready within the HPC system
-    The full path of the environment configuration script on the HPC target is: $REPO_PATH/$ENV_CONFIG_FILENAME
+  This action exports the following environment variables used in subsequent steps:
+    - TEMP_EXCHANGE_DIR_ON_HPC: path to the temporary exchange directory on the HPC target
+    - TEMP_EXCHANGE_DIR_ON_GH: path to the temporary exchange directory on the GitHub runner
+    - DEPLOYMENT_INFO_JSON_ON_HPC: path to the deployment info JSON file on the HPC target
+    - DEPLOYMENT_INFO_JSON_ON_GH: path to the deployment info JSON file on the GitHub runner
+    - REPO_PATH: path to this repository clone on the HPC target
+    - GH_ENV_EXPORT_SCRIPT: path on the HPC target of the bash script sourced to export variables
+      from the GitHub runner environment
 
 inputs:
   target-name:
@@ -26,15 +28,16 @@ inputs:
   host:
     description: "Hostname for SSH access to the HPC target."
     required: true
-  host-data:
-    description: "Hostname for SSH data transfer to the HPC target's data node."
-    required: true
   ssh-key:
     description: "Private SSH key for access to the HPC target."
     required: true
   ssh-key-passphrase:
     description: "Passphrase for the private SSH key."
     required: false
+  token:
+    description: "GitHub token with read permissions to this repository."
+    required: false
+    default: true
 outputs:
   private-key-path:
     description: "Path to the private SSH key file created in this action for SSH access to the HPC target. This can be used in subsequent steps that require SSH access to the HPC target."
@@ -42,27 +45,6 @@ outputs:
 runs:
   using: composite
   steps:
-    # Check that required inputs are non-empty
-    - name: Check inputs
-      shell: bash
-      run: |
-        if [[ ${CONTAINERISED_ENVS_DEBUG:-0} == 1 ]]; then
-          set -x
-        fi
-        declare -A inputs=(
-          [target-name]="${{ inputs.target-name }}"
-          [user]="${{ inputs.user }}"
-          [host]="${{ inputs.host }}"
-          [host-data]="${{ inputs.host-data }}"
-          [ssh-key]="${{ inputs.ssh-key }}"
-        )
-        for name in "${!inputs[@]}"; do
-          if [[ -z "${inputs[$name]}" ]]; then
-            echo "::error::Input '$name' cannot be empty."
-            exit 1
-          fi
-        done
-        
     # Sanity check that all needed GitHub Environment variables and secrets are non-empty
     - name: Check GitHub Environment configuration
       shell: bash
@@ -94,65 +76,81 @@ runs:
       uses: access-nri/actions/.github/actions/setup-ssh@main
       id: ssh
       with:
-        hosts: |
-          ${{ inputs.host }}
-          ${{ inputs.host-data }}
+        hosts: ${{ inputs.host }}:hpc
+        user: ${{ inputs.user }}
         private-key: ${{ inputs.ssh-key }}
         private-key-passphrase: ${{ inputs.ssh-key-passphrase }}
 
-    # We create a temporary repository directory on the HPC system and set its path 
-    # as a GitHub environment variable that can be used in subsequent steps.
-    - name: Create repository directory
-      id: create-repo-dir
+    # We create a temporary directory on the HPC system, to exchange files between
+    # the GitHub runner and the HPC system.
+    # We also define the path to the correspective directory and other useful files
+    # on the GitHub runner so we can use them in subsequent steps both within the HPC
+    # system and the GitHub runner.
+    - name: Create temporary exchange directory on HPC system
+      id: create-exchange-dir
       shell: bash
       run: |
         if [[ ${CONTAINERISED_ENVS_DEBUG:-0} == 1 ]]; then
           set -x
         fi
-        repo_path=$(
-          ssh ${{ inputs.user }}@${{ inputs.host }} \
-          -i ${{ steps.ssh.outputs.private-key-path }} \
-          mktemp -d
+        temp_exchange_dir=$(
+          ssh hpc 'mktemp -d'
         )
-        echo "REPO_PATH=$repo_path" >> $GITHUB_ENV
+        echo "TEMP_EXCHANGE_DIR_ON_HPC=$temp_exchange_dir" >> $GITHUB_ENV
+        # Set the path to the temporary exchange directory on the GitHub runner
+        temp_exchange_dir_on_gh_runner="${{github.workspace}}/from_hpc"
+        echo "TEMP_EXCHANGE_DIR_ON_GH=$temp_exchange_dir_on_gh_runner" >> $GITHUB_ENV
+        # Set the name of the deployment info JSON file
+        deployment_info_json_filename=deployment_info_${{ job.check_run_id }}.json
+        # Set the path to the deployment_info.json file on the HPC
+        echo "DEPLOYMENT_INFO_JSON_ON_HPC=$temp_exchange_dir/$deployment_info_json_filename" >> $GITHUB_ENV
+        # Set the path to the deployment_info.json file on the GH runner
+        echo "DEPLOYMENT_INFO_JSON_ON_GH=$temp_exchange_dir_on_gh_runner/$deployment_info_json_filename" >> $GITHUB_ENV
+        # Path to the repository clone on the HPC system
+        echo "REPO_PATH=$temp_exchange_dir/repository_clone" >> $GITHUB_ENV
 
-    # We set the env variable that stores the path to the hpc_target_deployment_info.json file containing
-    # information about the deployment to pass to the GitHub runner.
-    # For simplicity, we set this path to be within the REPO_PATH directory. This way, the file will
-    # also be deleted when we delete the REPO_PATH directory.
-    # We also set the path to the hpc_target_deployment_info.json file on the GitHub runner, which
-    # we will use to retrieve the file from the HPC system and upload it as an artifact at the end of the workflow.
-    - name: Set hpc_target_deployment_info.json path env variable
+    # We create a bash script to export variables from
+    # the GitHub runner environment to the HPC system
+    - name: Set GitHub runner environment export script
       shell: bash
       run: |
-        json_name='hpc_target_deployment_info_${{ job.check_run_id }}.json'
-        echo "HPC_TARGET_DEPLOYMENT_INFO_JSON_PATH=$REPO_PATH/$json_name" >> $GITHUB_ENV
-        echo "HPC_TARGET_DEPLOYMENT_INFO_JSON_PATH_ON_GITHUB_RUNNER=${{ github.workspace }}/$json_name" >> $GITHUB_ENV
-
-    # We create the ENV_CONFIG_FILENAME bash script that exports multiple configuration 
-    # env variables when sourced. 
-    # This will allow us to source the script in any following step to have the CI environment 
-    # ready within the HPC system.
-    - name: Set configuration env script
-      shell: bash
-      run: |
-        env_config_filename='.env_config'
-        echo "ENV_CONFIG_FILENAME=$env_config_filename" >> $GITHUB_ENV
-        bash infrastructure/scripts/write_env_exports.sh > "$env_config_filename"
-
-    # Sync current directory (repository + ENV_CONFIG_FILENAME script) to the HPC system
-    - name: Sync repository to HPC system
-      id: sync-repo
-      shell: bash
-      run: |
-        set -euo pipefail
         if [[ ${CONTAINERISED_ENVS_DEBUG:-0} == 1 ]]; then
           set -x
         fi
-        rsync -e 'ssh -i ${{ steps.ssh.outputs.private-key-path }}' \
-          -avz \
-          --delete \
-          --exclude=/.git/ \
-          --exclude=/.github/ \
-          ./ \
-          "${{ inputs.user }}@${{ inputs.host-data }}:$REPO_PATH"
+        # Set GitHub runner environment export script path within the HPC system
+        gh_env_export_script_on_hpc="$TEMP_EXCHANGE_DIR_ON_HPC/gh_env_exports_on_hpc.sh"
+        gh_env_export_script_on_gh_runner=gh_env_exports_on_gh_runner.sh
+        # Generate GitHub runner environment export script
+        source infrastructure/scripts/github_runner_env_export.sh > "$gh_env_export_script_on_gh_runner"
+        echo "GH_ENV_EXPORT_SCRIPT=$gh_env_export_script_on_hpc" >> $GITHUB_ENV
+        # Copy the GitHub runner environment export script to the HPC system
+        rsync "$gh_env_export_script_on_gh_runner" hpc:"$gh_env_export_script_on_hpc"
+
+    # We clone this repository to make the repository files available within the HPC system.
+    # For simplicity, instead of actually cloning the whole repository, we just initialise
+    # an empty git repository, add the remote, fetch the specific commit and check it out.
+    # This saves time and disk space, especially for large repositories.
+    - name: Clone repository on HPC system
+      id: clone-repo
+      shell: bash
+      env:
+        GITHUB_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+      run: |
+        ssh hpc << 'HPC_SSH_EOF'
+          if [[ '${{ env.CONTAINERISED_ENVS_DEBUG }}' == 1 ]]; then
+            set -x
+          fi
+          set -euo pipefail
+          repo_path='${{ env.REPO_PATH }}'
+          git config --list
+          # Initialise an empty git repository 
+          git init "$repo_path"
+          # Add remote with GH_TOKEN for authentication
+          git -C "$repo_path" \
+            remote add origin 'https://x-access-token:${{ inputs.token }}@github.com/${{ github.repository }}.git'
+          # Fetch the specific commit and check it out
+          git -C "$repo_path" \
+            fetch --depth 1 origin '${{ env.GITHUB_SHA }}'
+          git -C "$repo_path" \
+            checkout FETCH_HEAD
+        HPC_SSH_EOF

--- a/.github/workflows/closed_pr.yml
+++ b/.github/workflows/closed_pr.yml
@@ -17,11 +17,11 @@ env:
   TEST_ENV: ${{ vars.TEST_ENV }}
 
 jobs:
-  # In general, this workflow should always be "in sync" with the `deploy_env.yml` workflow.
+  # In general, this workflow should always be "in sync" with the `deploy_module.yml` workflow.
   # This means that for the env deletion and deployment to DEVELOPMENT PRODUCTION, this
-  # workflow should follow the same logic that is used in the `deploy_env.yml` workflow to detect
+  # workflow should follow the same logic that is used in the `deploy_module.yml` workflow to detect
   # and deploy the STAGING environments.
-  # For this reason, we run the parse_changed_files job identically to how we do in the `deploy_env.yml`
+  # For this reason, we run the parse_changed_files job identically to how we do in the `deploy_module.yml`
   # workflow, to make sure that we are detecting the same changes
   parse_changed_files:
     name: Parse changed files
@@ -110,7 +110,7 @@ jobs:
       fail-fast: false
       matrix:
         environment: ${{ fromJson(needs.get-environments.outputs.envs_to_deploy) }}
-    uses: ./.github/workflows/deploy_env.yml
+    uses: ./.github/workflows/deploy_module.yml
     with:
       environment: "${{ matrix.environment }}"
       version: "${{ needs.set_version.outputs.version }}"
@@ -127,7 +127,7 @@ jobs:
       fail-fast: false
       matrix:
         environment: ${{ fromJson(needs.get-environments.outputs.envs_to_delete) }}
-    uses: ./.github/workflows/deploy_env.yml
+    uses: ./.github/workflows/deploy_module.yml
     with:
       environment: "${{ matrix.environment }}"
       staging: false

--- a/.github/workflows/deploy_module.yml
+++ b/.github/workflows/deploy_module.yml
@@ -168,6 +168,14 @@ jobs:
           # echo "CONTAINERISED_ENVS_DEBUG=${{ runner.debug }}" >> $GITHUB_ENV
           echo "CONTAINERISED_ENVS_DEBUG=1" >> $GITHUB_ENV
       
+      # This action exports the following environment variables used in subsequent steps:
+      # - TEMP_EXCHANGE_DIR_ON_HPC: path to the temporary exchange directory on the HPC target
+      # - TEMP_EXCHANGE_DIR_ON_GH: path to the temporary exchange directory on the GitHub runner
+      # - DEPLOYMENT_INFO_JSON_ON_HPC: path to the deployment info JSON file on the HPC target
+      # - DEPLOYMENT_INFO_JSON_ON_GH: path to the deployment info JSON file on the GitHub runner
+      # - REPO_PATH: path to this repository clone on the HPC target
+      # - GH_ENV_EXPORT_SCRIPT: path on the HPC target of the bash script sourced to export variables
+      #   from the GitHub runner environment
       - name: Set up HPC target
         uses: ./.github/actions/set_up_hpc_target
         id: set-up-hpc-target
@@ -175,90 +183,101 @@ jobs:
           target-name: ${{ matrix.hpc-target }}
           user: ${{ secrets.USER }}
           host: ${{ secrets.HOST }}
-          host-data: ${{ secrets.HOST_DATA || secrets.HOST }}
           ssh-key: ${{ secrets.SSH_KEY }}
           ssh-key-passphrase: ${{ secrets.SSH_KEY_PASSPHRASE }}
+          token: ${{ secrets.REPO_CONTENT_READ_TOKEN }}
 
       - name: Deploy staging environment
         if: inputs.staging
         id: deploy-staging
         run: |
-          # Run deployment
-          ssh ${{ secrets.USER }}@${{ secrets.HOST }} \
-            -i ${{ steps.set-up-hpc-target.outputs.private-key-path }} \
-            /bin/bash <<EOT
+          ssh hpc <<'HPC_SSH_EOF'
             set -euo pipefail
-            if [[ ${CONTAINERISED_ENVS_DEBUG:-0} == 1 ]]; then
+            if [[ '${{ env.CONTAINERISED_ENVS_DEBUG }}' == 1 ]]; then
               set -x
             fi
-            # Set configuration environment
-            source '$REPO_PATH/$ENV_CONFIG_FILENAME'
+            # GitHub runner environment export
+            source '${{ env.GH_ENV_EXPORT_SCRIPT }}'
             # Set job name prefix
             export JOB_NAME_PREFIX=staging
-            # Set DEPLOYMENT_STAGE to STAGING
+            # Set DEPLOYMENT_STAGE
             export DEPLOYMENT_STAGE=STAGING
-            "\$INFRA_SCRIPTS_DIR/submit_pbs_job.sh" "\$INFRA_SCRIPTS_DIR/build_and_deploy_env.sh"
-          EOT
+            source "$INFRA_SCRIPTS_DIR/submit_pbs_job.sh" "$INFRA_SCRIPTS_DIR/build_and_deploy.sh"
+          HPC_SSH_EOF
       
       - name: Deploy production environment
         if: inputs.production
         id: deploy-production
         run: |
-          # Run deployment
-          ssh ${{ secrets.USER }}@${{ secrets.HOST }} \
-            -i ${{ steps.set-up-hpc-target.outputs.private-key-path }} \
-            /bin/bash <<EOT
+          ssh hpc <<'HPC_SSH_EOF'
             set -euo pipefail
-            if [[ ${CONTAINERISED_ENVS_DEBUG:-0} == 1 ]]; then
+            if [[ '${{ env.CONTAINERISED_ENVS_DEBUG }}' == 1 ]]; then
               set -x
             fi
-            # Set configuration environment
-            source '$REPO_PATH/$ENV_CONFIG_FILENAME'
+            # GitHub runner environment export
+            source '${{ env.GH_ENV_EXPORT_SCRIPT }}'
             # Set job name prefix
             export JOB_NAME_PREFIX=production
-            # Set DEPLOYMENT_STAGE to PRODUCTION
+            # Set DEPLOYMENT_STAGE
             export DEPLOYMENT_STAGE=PRODUCTION
-            "\$INFRA_SCRIPTS_DIR/submit_pbs_job.sh" "\$INFRA_SCRIPTS_DIR/build_and_deploy_env.sh"
-          EOT
+            source "$INFRA_SCRIPTS_DIR/submit_pbs_job.sh" "$INFRA_SCRIPTS_DIR/build_and_deploy.sh"
+          HPC_SSH_EOF
     
-      - name: Get hpc_target_deployment_info JSON
-        # We always run this if any deployment is triggered, even if it failed (i.e., inputs.staging=true)
-        # We try to retrieve the hpc_target_deployment_info.json file created by the deployment job.
-        # If we fail, we create the hpc_target_deployment_info.json file.
-        if: always() && !cancelled() && inputs.staging == true
-        id: get-deployment-info
+      # Get files within the TEMP_EXCHANGE_DIR_ON_HPC to GitHub Runner
+      - name: Get files from temporary exchange directory on HPC system
+        if: always() && !cancelled() && steps.set-up-hpc-target.outcome == 'success'
+        id: get-files-from-hpc
         run: |
-          if ! rsync -e "ssh -i ${{ steps.set-up-hpc-target.outputs.private-key-path }}" \
-            ${{ secrets.USER }}@${{ secrets.HOST }}:"$HPC_TARGET_DEPLOYMENT_INFO_JSON_PATH" \
-            "$HPC_TARGET_DEPLOYMENT_INFO_JSON_PATH_ON_GITHUB_RUNNER"; then
-              echo "::warning::Failed to retrieve hpc_target_deployment_info JSON file from HPC system. Creating JSON file:"
-              # set SUCCESS and DEPLOYMENT_STAGE for the create_hpc_target_deployment_info_json.sh script
-              export SUCCESS=false
-              export DEPLOYMENT_STAGE=${{ inputs.production == true && 'PRODUCTION' || 'STAGING' }}
-              bash infrastructure/scripts/create_hpc_target_deployment_info_json.sh "$HPC_TARGET_DEPLOYMENT_INFO_JSON_PATH_ON_GITHUB_RUNNER"
+          set -euo pipefail
+          if [[ ${CONTAINERISED_ENVS_DEBUG:-0} == 1 ]]; then
+            set -x
+          fi
+          # Get files from TEMP_EXCHANGE_DIR_ON_HPC to GitHub runner
+          mkdir -p "$TEMP_EXCHANGE_DIR_ON_GH"
+          rsync \
+            -avh \
+            --no-perms \
+            --no-owner \
+            --no-group \
+            hpc:"$TEMP_EXCHANGE_DIR_ON_HPC/" "$TEMP_EXCHANGE_DIR_ON_GH"
+          
+      - name: Sanity check on deployment info JSON file
+        if: always() && !cancelled() && steps.get-files-from-hpc.outcome == 'success'
+        continue-on-error: true
+        id: deployment-info-json-sanity-check
+        run: |
+          set -euo pipefail
+          if [[ ${CONTAINERISED_ENVS_DEBUG:-0} == 1 ]]; then
+            set -x
+          fi
+          if [[ ! -f "$DEPLOYMENT_INFO_JSON_ON_GH" ]]; then
+            echo "::error:: The deployment info JSON file was not produced."
+            exit 1
+          else
+            cat "$DEPLOYMENT_INFO_JSON_ON_GH"
           fi
     
       - name: Set message for summary
-        # We always run this if the get-deployment-info step succeeds.
-        if: always() && !cancelled() && steps.get-deployment-info.outcome == 'success'
+        # We always run this if the deployment-info-json-sanity-check step succeeds.
+        if: always() && !cancelled() && steps.deployment-info-json-sanity-check.outcome == 'success'
         id: set-message-summary
         uses: ./.github/actions/set_message
         with:
           message-type: summary
-          data-file: ${{ env.HPC_TARGET_DEPLOYMENT_INFO_JSON_PATH_ON_GITHUB_RUNNER }}
+          data-file: ${{ env.DEPLOYMENT_INFO_JSON_ON_GH }}
 
       - name: Set message in the step summary
         # We always run this if the set-message-summary step succeeds.
         if: always() && !cancelled() && steps.set-message-summary.outcome == 'success'
         run: cat "${{ steps.set-message-summary.outputs.message-file-path }}" >> $GITHUB_STEP_SUMMARY
 
-      - name: Save hpc_target_deployment_info JSON as an artifact
-        # We always run this if the get-deployment-info step succeeds.
-        if: always() && !cancelled() && steps.get-deployment-info.outcome == 'success'
+      - name: Save deployment info JSON as an artifact
+        # We always run this if the deployment-info-json-sanity-check step succeeds.
+        if: always() && !cancelled() && steps.deployment-info-json-sanity-check.outcome == 'success'
         uses: actions/upload-artifact@v7
         with:
-          path: ${{ env.HPC_TARGET_DEPLOYMENT_INFO_JSON_PATH_ON_GITHUB_RUNNER }}
-          name: deployment_${{ matrix.hpc-target }}_${{ inputs.environment }}_${{ inputs.version }}
+          path: ${{ env.DEPLOYMENT_INFO_JSON_ON_GH }}
+          name: deployment_info_${{ matrix.hpc-target }}_${{ inputs.environment }}_${{ inputs.version }}
     
       - name: Delete staging files
         # Delete staging files if we deploy to production, or if there are no deployments 
@@ -276,11 +295,9 @@ jobs:
             # Delete staging files
             "\$INFRA_SCRIPTS_DIR/delete_staging_files.sh" ${{ github.event.number }}
           EOT
-
-      - name: Delete repository on HPC system
+    
+      # Delete the temporary exchange directory that we created on the HPC system
+      - name: Delete temporary exchange directory on HPC system
+        id: delete-temp-dir
         if: always() && steps.set-up-hpc-target.outcome == 'success'
-        run: |
-          ssh ${{ secrets.USER }}@${{ secrets.HOST }} \
-            -i ${{ steps.set-up-hpc-target.outputs.private-key-path }} /bin/bash <<EOT
-            rm -rf '$REPO_PATH'
-          EOT
+        run: ssh hpc 'rm -rfv ${{ env.TEMP_EXCHANGE_DIR_ON_HPC }}'

--- a/.github/workflows/deploy_module.yml
+++ b/.github/workflows/deploy_module.yml
@@ -284,17 +284,18 @@ jobs:
         # (e.g., closed PR)
         if: inputs.production == true || inputs.staging == false
         run: |
-          ssh ${{ secrets.USER }}@${{ secrets.HOST }} -i ${{ steps.set-up-hpc-target.outputs.private-key-path }} /bin/bash <<EOT
+          ssh hpc <<'HPC_SSH_EOF'
             set -euo pipefail
-            if [[ ${CONTAINERISED_ENVS_DEBUG:-0} == 1 ]]; then
+            if [[ '${{env.CONTAINERISED_ENVS_DEBUG}}' == 1 ]]; then
               set -x
             fi
-            # Set configuration environment
-            source '$REPO_PATH/$ENV_CONFIG_FILENAME'
+            # GitHub runner environment export
+            source '${{ env.GH_ENV_EXPORT_SCRIPT }}'
+            # Set DEPLOYMENT_STAGE
             export DEPLOYMENT_STAGE=STAGING
             # Delete staging files
-            "\$INFRA_SCRIPTS_DIR/delete_staging_files.sh" ${{ github.event.number }}
-          EOT
+            "$INFRA_SCRIPTS_DIR/delete_staging_files.sh" ${{ github.event.number }}
+          HPC_SSH_EOF
     
       # Delete the temporary exchange directory that we created on the HPC system
       - name: Delete temporary exchange directory on HPC system

--- a/.github/workflows/deploy_payu_telemetry_config.yml
+++ b/.github/workflows/deploy_payu_telemetry_config.yml
@@ -189,7 +189,6 @@ jobs:
           # Reset existing acls
           setfacl -b '${{env.PAYU_TELEMETRY_CONFIG_PATH}}'
           # Change group ownership
-          chgrp "$GROUP_OWNER" "$arg"
           chgrp '${{env.GROUP_OWNER}}' '${{env.PAYU_TELEMETRY_CONFIG_PATH}}'
           # Define permissions
           acls='u::rw-' # rw- for user

--- a/.github/workflows/deploy_payu_telemetry_config.yml
+++ b/.github/workflows/deploy_payu_telemetry_config.yml
@@ -162,38 +162,39 @@ jobs:
       id: set-up-ssh
       with:
         hosts: |
-          ${{ env.HOST }}
-          ${{ env.HOST_DATA }}
+          ${{ env.HOST }}:hpc
+          ${{ env.HOST_DATA }}:hpc-data
         private-key: ${{ env.SSH_KEY }}
         private-key-passphrase: ${{ env.SSH_KEY_PASSPHRASE }}
     
-    - name: Create payu telemetry config parent directory
-      run: |
-        ssh $USER@$HOST \
-          -i ${{ steps.set-up-ssh.outputs.private-key-path }} \
-          mkdir -p $(dirname $PAYU_TELEMETRY_CONFIG_PATH)
-    
     - name: Deploy telemetry config
       run: |
-        rsync -e 'ssh -i ${{ steps.set-up-ssh.outputs.private-key-path }}' \
-          -avz \
-          $TELEMETRY_CONFIG_NAME \
-          "$USER@${{ env.HOST_DATA || env.HOST }}:$PAYU_TELEMETRY_CONFIG_PATH"
+        # Create payu telemetry config parent directory
+        ssh hpc 'mkdir -p $(dirname ${{env.PAYU_TELEMETRY_CONFIG_PATH}})'
+        # Deploy telemetry config to HPC target
+        rsync \
+          -avh \
+          --no-perms \
+          --no-owner \
+          --no-group \
+          "$TELEMETRY_CONFIG_NAME" hpc-data:"$PAYU_TELEMETRY_CONFIG_PATH"
 
     - name: Set permissions
       run: |
-        ssh $USER@$HOST \
-          -i ${{ steps.set-up-ssh.outputs.private-key-path }} << EOF
-        set -euo pipefail
-        set -x
-        # Reset existing acls
-        setfacl -b '$PAYU_TELEMETRY_CONFIG_PATH'
-        # Change group ownership
-        chgrp '$GROUP_OWNER' '$PAYU_TELEMETRY_CONFIG_PATH'
-        # Define permissions
-        acls='u::rw-' # rw- for user
-        acls+=',g::r--' # r-- for group
-        acls+=',o::---' # no permissions for others
-        # Set permissions
-        setfacl -m \$acls '$PAYU_TELEMETRY_CONFIG_PATH'
+        ssh hpc << 'HPC_SSH_EOF'
+          set -euo pipefail
+          if [[ '${{env.CONTAINERISED_ENVS_DEBUG}}' == 1 ]]; then
+            set -x
+          fi
+          # Reset existing acls
+          setfacl -b '${{env.PAYU_TELEMETRY_CONFIG_PATH}}'
+          # Change group ownership
+          chgrp "$GROUP_OWNER" "$arg"
+          chgrp '${{env.GROUP_OWNER}}' '${{env.PAYU_TELEMETRY_CONFIG_PATH}}'
+          # Define permissions
+          acls='u::rw-' # rw- for user
+          acls+=',g::r--' # r-- for group
+          acls+=',o::---' # no permissions for others
+          # Set permissions
+          setfacl -m "$acls" '${{env.PAYU_TELEMETRY_CONFIG_PATH}}'
         EOF

--- a/.github/workflows/deploy_to_staging.yml
+++ b/.github/workflows/deploy_to_staging.yml
@@ -155,7 +155,7 @@ jobs:
       fail-fast: false
       matrix:
         environment: ${{ fromJson(needs.get-environments.outputs.dev_envs) }}
-    uses: ./.github/workflows/deploy_env.yml
+    uses: ./.github/workflows/deploy_module.yml
     with:
       environment: "${{ matrix.environment }}"
       # We prepend `dev-` to the version of a DEVELOPMENT module
@@ -172,7 +172,7 @@ jobs:
       fail-fast: false
       matrix:
         environment: ${{ fromJson(needs.get-environments.outputs.stable_envs) }}
-    uses: ./.github/workflows/deploy_env.yml
+    uses: ./.github/workflows/deploy_module.yml
     with:
       environment: "${{ matrix.environment }}"
       version: "${{ needs.set_version_stable.outputs.version }}"
@@ -230,7 +230,7 @@ jobs:
         uses: actions/download-artifact@v8
         id: download-artifacts
         with:
-          pattern: deployment_*
+          pattern: deployment_info_*
           merge-multiple: true
           path: downloaded_artifacts
       

--- a/.github/workflows/release_dev_module.yml
+++ b/.github/workflows/release_dev_module.yml
@@ -33,7 +33,7 @@ jobs:
   deploy:
     name: Deploy DEVELOPMENT ${{ inputs.environment }} environment to PRODUCTION
     needs: [set_version]
-    uses: ./.github/workflows/deploy_env.yml
+    uses: ./.github/workflows/deploy_module.yml
     with:
       environment: "${{ inputs.environment }}"
       version: "${{ needs.set_version.outputs.version }}"

--- a/.github/workflows/release_module.yml
+++ b/.github/workflows/release_module.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   deploy:
-    uses: ./.github/workflows/deploy_env.yml
+    uses: ./.github/workflows/deploy_module.yml
     with:
       environment: ${{ inputs.environment }}
       version: ${{ inputs.version }}
@@ -37,13 +37,13 @@ jobs:
         uses: actions/download-artifact@v8
         id: download-artifact
         with:
-          pattern: deployment_*
+          pattern: deployment_info_*
           path: ${{github.workspace}}/downloaded_artifact
       
       - name: Get info from deployment info JSON
         id: get-info
         run: |
-          deployment_info_json_path=$(find ${{steps.download-artifact.outputs.download-path}} -name 'deployment_*.json')
+          deployment_info_json_path=$(find ${{steps.download-artifact.outputs.download-path}} -name 'deployment_info_*.json')
           module_name=$(jq -r 'deployments[].module_name' "$deployment_info_json_path")
           module_version=$(jq -r 'deployments[].module_version' "$deployment_info_json_path")
           commit_sha=$(jq -r 'deployments[].commit_sha' "$deployment_info_json_path")

--- a/defaults/scripts/deployment_post_script.sh
+++ b/defaults/scripts/deployment_post_script.sh
@@ -1,4 +1,4 @@
-# This script is sourced at the end of the deployment script `build_and_deploy_env.sh`, and is used to
+# This script is sourced at the end of the deployment script `build_and_deploy.sh`, and is used to
 # define custom logic to be run as part of the deployment process for specific environments.
 
 # Specific environments should override this empty script by defining the 

--- a/infrastructure/scripts/build_and_deploy.sh
+++ b/infrastructure/scripts/build_and_deploy.sh
@@ -32,7 +32,7 @@ cleanup_env() {
     # _exit_status vaiable is initialised within the register_exit_trap_cmd function
     if [ $_exit_status -ne 0 ]; then
         echo "Error! Build failed. Cleaning up module version '$MODULE_NAME/$MODULE_VERSION' related files..." >&2
-        delete_files_in_manifest
+        delete_files_in_manifest "$FILES_MANIFEST_PATH"
     fi
 }
 register_exit_trap_cmd cleanup_env $TRAP_PRIORITY_LAST

--- a/infrastructure/scripts/build_and_deploy.sh
+++ b/infrastructure/scripts/build_and_deploy.sh
@@ -58,7 +58,7 @@ update_hpc_target_deployment_info() {
     export SUCCESS=$( [ $_exit_status -eq 0 ] && echo true || echo false )
     # Update the HPC target deployment info JSON
     source "$INFRA_SCRIPTS_DIR/create_hpc_target_deployment_info_json.sh" \
-        "$HPC_TARGET_DEPLOYMENT_INFO_JSON_PATH" \
+        "$DEPLOYMENT_INFO_JSON_ON_HPC" \
         --key env_lock "$ENV_LOCK"
 }
 register_exit_trap_cmd update_hpc_target_deployment_info $TRAP_PRIORITY_FIRST

--- a/infrastructure/scripts/build_and_deploy.sh
+++ b/infrastructure/scripts/build_and_deploy.sh
@@ -18,7 +18,7 @@ fi
 exec &> "$JOB_LOG_FILE"
 
 # Set configuration env variables
-source "$INSTALL_CONFIG"
+source "$INFRA_SCRIPTS_DIR/install_config.sh"
 
 ### Initialise directories
 # Make sure the target module directory does not already exist, to avoid accidentally overwriting an existing environment.
@@ -236,7 +236,7 @@ source "$INFRA_SCRIPTS_DIR/generate_env_lock.sh"
 echo "Environment lock created to: '$ENV_LOCK_FILE_PATH'"
 
 ### CLEANUP OLDEST DEVELOPMENT ENV FOR PRODUCTION
-source "$INFRA_SCRIPTS_DIR/cleanup_old_dev_env.sh"
+source "$INFRA_SCRIPTS_DIR/cleanup_old_dev_module.sh"
 
 ### ENSURE RIGHT PERMISSIONS
 set_perms "$APP_VERSION_DIR"

--- a/infrastructure/scripts/cleanup_old_dev_env.sh
+++ b/infrastructure/scripts/cleanup_old_dev_env.sh
@@ -1,4 +1,4 @@
-# This file is sourced in the build_and_deploy_env.sh script to cleanup oldest DEVELOPMENT
+# This file is sourced in the build_and_deploy.sh script to cleanup oldest DEVELOPMENT
 # modules for PRODUCTION if the number of dev env versions is greater than MAX_DEV_MODULE_VERSIONS
 
 # Only for DEVELOPMENT envs in PRODUCTION

--- a/infrastructure/scripts/cleanup_old_dev_module.sh
+++ b/infrastructure/scripts/cleanup_old_dev_module.sh
@@ -1,5 +1,5 @@
 # This file is sourced in the build_and_deploy.sh script to cleanup oldest DEVELOPMENT
-# modules for PRODUCTION if the number of dev env versions is greater than MAX_DEV_MODULE_VERSIONS
+# modules for PRODUCTION if the number of dev env versions is greater than MAX_N_DEV_VERSIONS
 
 # Only for DEVELOPMENT envs in PRODUCTION
 if [[ "$MODULE_TYPE" == DEVELOPMENT ]] && [[ "$DEPLOYMENT_STAGE" == PRODUCTION ]]; then
@@ -11,11 +11,11 @@ if [[ "$MODULE_TYPE" == DEVELOPMENT ]] && [[ "$DEPLOYMENT_STAGE" == PRODUCTION ]
         | sort
     )
     num_versions=$(echo "$module_versions" | wc -l)
-    if [[ $num_versions -gt $MAX_DEV_MODULE_VERSIONS ]]; then
+    if [[ $num_versions -gt $MAX_N_DEV_VERSIONS ]]; then
         oldest_version_dir=$(echo "$module_versions" | head -n 1 | cut -d' ' -f2-)
         oldest_version_manifest="$oldest_version_dir/$FILES_MANIFEST_NAME"
         oldest_version=$(basename "$oldest_version_dir")
-        msg="Number of '$MODULE_NAME' DEVELOPMENT versions in PRODUCTION greater than '$MAX_DEV_MODULE_VERSIONS'. "
+        msg="Number of '$MODULE_NAME' DEVELOPMENT versions in PRODUCTION greater than '$MAX_N_DEV_VERSIONS'. "
         msg+="Cleaning up oldest '$MODULE_NAME' DEVELOPMENT version: $oldest_version"
         echo "$msg"
         delete_files_in_manifest "$oldest_version_manifest"

--- a/infrastructure/scripts/delete_staging_files.sh
+++ b/infrastructure/scripts/delete_staging_files.sh
@@ -37,7 +37,7 @@ source "$INSTALL_CONFIG"
 if [[ -z "${1:-}" ]]; then
     # No arguments are provided: only delete the files associated with the current version
     echo "Deleting STAGING files associated to version '$MODULE_VERSION':"
-    delete_files_in_manifest
+    delete_files_in_manifest "$FILES_MANIFEST_PATH"
 elif [[ "${1:-}" == '--all' ]]; then
     # If --all flag is provided, delete all files in the staging directories
     # We perform an extra check to avoid runing the rm command with empty variables

--- a/infrastructure/scripts/delete_staging_files.sh
+++ b/infrastructure/scripts/delete_staging_files.sh
@@ -31,7 +31,7 @@ elif [[ ${1:-} != '--all' && ! ${1:-0} =~ ^[0-9]+$ ]]; then
 fi
 
 # Set configuration env variables
-source "$INSTALL_CONFIG"
+source "$INFRA_SCRIPTS_DIR/install_config.sh"
 
 # Delete module files
 if [[ -z "${1:-}" ]]; then

--- a/infrastructure/scripts/functions.sh
+++ b/infrastructure/scripts/functions.sh
@@ -71,8 +71,7 @@ function register_exit_trap_cmd() {
 
 function delete_files_in_manifest() {
     # Delete all files and folders associated with a version, which are listed in the manifest $1.
-    # If $1 is not provided, it defaults to the FILES_MANIFEST_PATH for the current module version.
-    local manifest_file="${1:-$FILES_MANIFEST_PATH}"
+    local manifest_file="$1"
     if [[ ! -f "$manifest_file" ]]; then
         echo "Error: manifest file '$manifest_file' not found." >&2
         return 1
@@ -80,17 +79,6 @@ function delete_files_in_manifest() {
     # Make sure to split the manifest by newlines and not by spaces (-d '\n')
     # Do not run if the manifest is empty (--no-run-if-empty)
     xargs --no-run-if-empty -d '\n' rm -vrf < "$manifest_file"
-}
-
-function in_array() {
-    # Assumes first arg is the string to search for and the others are an array
-    local string item
-    string="$1"
-    shift
-    for item in "$@"; do
-        [[ "$item" == "$string" ]] && return 0
-    done
-    return 1
 }
 
 function set_perms() {

--- a/infrastructure/scripts/generate_env_lock.sh
+++ b/infrastructure/scripts/generate_env_lock.sh
@@ -1,4 +1,4 @@
-# This file is sourced in the build_and_deploy_env.sh script to generate a lock file 
+# This file is sourced in the build_and_deploy.sh script to generate a lock file 
 # for the containerised environment.
 # It generate an environment lock file using `micromamba env export`, then removes the
 # 'prefix:' line and sets the environment name to $MODULE_NAME-$MODULE_VERSION.

--- a/infrastructure/scripts/github_runner_env_export.sh
+++ b/infrastructure/scripts/github_runner_env_export.sh
@@ -2,7 +2,7 @@
 # needed for the deploy process on the HPC system.
 
 # The bash variables in this script are taken from the GitHub job environment 
-# defined within the deploy_env.yml workflow.
+# defined within the deploy_module.yml workflow.
 
 set -euo pipefail
 
@@ -44,7 +44,7 @@ export MODULE_VERSION='$MODULE_VERSION'
 export MODULE_TYPE='$MODULE_TYPE'
 export HPC_TARGET='$HPC_TARGET'
 export HPC_NAME='$HPC_NAME'
-export HPC_TARGET_DEPLOYMENT_INFO_JSON_PATH='$HPC_TARGET_DEPLOYMENT_INFO_JSON_PATH'
+export DEPLOYMENT_INFO_JSON_ON_HPC='$DEPLOYMENT_INFO_JSON_ON_HPC'
 export STARTED_AT='$STARTED_AT'
 export DEFAULTS_DIR='$defaults_dir'
 export SCRIPTS_DIR='$scripts_dir'

--- a/infrastructure/scripts/github_runner_env_export.sh
+++ b/infrastructure/scripts/github_runner_env_export.sh
@@ -4,41 +4,21 @@
 # The bash variables in this script are taken from the GitHub job environment 
 # defined within the deploy_module.yml workflow.
 
-set -euo pipefail
-
-if [[ "${CONTAINERISED_ENVS_DEBUG:-0}" == "1" ]]; then
-    set -x
-fi
-
-# Strip slash from STABLE_PRODUCTION_BASE_DIR
-STABLE_PRODUCTION_BASE_DIR=${STABLE_PRODUCTION_BASE_DIR%/}
-# Path to default files within the repository
-defaults_dir="$REPO_PATH/defaults"
-# Path to the scripts wihtin the default files
-scripts_dir="$defaults_dir/scripts"
-# Path to the infrastructure scripts directory
+# Path to the infrastructure scripts directory within the repository
 infra_scripts_dir="$REPO_PATH/infrastructure/scripts"
-# Path to the install config file
-install_config="$infra_scripts_dir/install_config.sh"
-# Name for the containerised environments root dir
-containerised_envs_root_dir_name=containerised_envs
-# Name of the directory where all apps will be stored
-apps_dir_name=apps
-# Name of the directory where all modules will be stored
-modules_dir_name=modules
-# Path to the functions script
-functions_path="$infra_scripts_dir/functions.sh"
 
 # write export script
 cat <<EOF
+export CONTAINERISED_ENVS_DEBUG=$CONTAINERISED_ENVS_DEBUG
+export TEMP_EXCHANGE_DIR='$TEMP_EXCHANGE_DIR'
+export STABLE_PRODUCTION_BASE_DIR='$STABLE_PRODUCTION_BASE_DIR'
+export REPO_PATH='$REPO_PATH'
+export INFRA_SCRIPTS_DIR='$infra_scripts_dir'
 export GROUP_OWNER='$GROUP_OWNER'
 export PBS_PROJECT='$PBS_PROJECT'
 export PBS_STORAGE='$PBS_STORAGE'
 export SINGULARITY_EXE='$SINGULARITY_EXE'
 export JQ_EXE='$JQ_EXE'
-export STABLE_PRODUCTION_BASE_DIR='$STABLE_PRODUCTION_BASE_DIR'
-export CONTAINERISED_ENVS_DEBUG=$CONTAINERISED_ENVS_DEBUG
-export REPO_PATH='$REPO_PATH'
 export MODULE_NAME='$MODULE_NAME'
 export MODULE_VERSION='$MODULE_VERSION'
 export MODULE_TYPE='$MODULE_TYPE'
@@ -46,14 +26,6 @@ export HPC_TARGET='$HPC_TARGET'
 export HPC_NAME='$HPC_NAME'
 export DEPLOYMENT_INFO_JSON_ON_HPC='$DEPLOYMENT_INFO_JSON_ON_HPC'
 export STARTED_AT='$STARTED_AT'
-export DEFAULTS_DIR='$defaults_dir'
-export SCRIPTS_DIR='$scripts_dir'
-export INFRA_SCRIPTS_DIR='$infra_scripts_dir'
-export INSTALL_CONFIG='$install_config'
-export CONTAINERISED_ENVS_ROOT_DIR_NAME='$containerised_envs_root_dir_name'
-export APPS_DIR_NAME='$apps_dir_name'
-export MODULES_DIR_NAME='$modules_dir_name'
-export FUNCTIONS_PATH='$functions_path'
 export PAYU_TELEMETRY_CONFIG_PATH='$PAYU_TELEMETRY_CONFIG_PATH'
 export DEPLOYMENT_WORKFLOW_RUN_ID='$DEPLOYMENT_WORKFLOW_RUN_ID'
 export DEPLOYMENT_WORKFLOW_URL='$DEPLOYMENT_WORKFLOW_URL'

--- a/infrastructure/scripts/install_config.sh
+++ b/infrastructure/scripts/install_config.sh
@@ -4,14 +4,16 @@
 # Some of the variables defaults in this script can be overridden for a specific environment using the
 # 'environments/<env_name>/overrides/scripts/default_config.sh' file.
 
-set -euo pipefail
-if [[ "${CONTAINERISED_ENVS_DEBUG:-0}" == 1 ]]; then
-    set -x
-fi
+# Make functions available
+source "$INFRA_SCRIPTS_DIR/functions.sh"
 
 # Set named constant priorities for the register_exit_trap_cmd function
 export TRAP_PRIORITY_FIRST=10 # Runs first (Used for setup commands)
 export TRAP_PRIORITY_LAST=90 # Runs last (e.g. used for commands that delete files/folders)
+
+# Maximum number of DEVELOPMENT module versions to keep in PRODUCTION simultaneously.
+# If a new deployment causes the total to exceed this limit, the oldest version is deleted.
+export MAX_N_DEV_VERSIONS=3
 
 # Sanity check on DEPLOYMENT_STAGE
 if [[ "$DEPLOYMENT_STAGE" != STAGING && "$DEPLOYMENT_STAGE" != PRODUCTION ]]; then
@@ -25,40 +27,43 @@ if [[ "$MODULE_TYPE" != STABLE && "$MODULE_TYPE" != DEVELOPMENT ]]; then
     exit 1
 fi
 
-# Make functions available
-source "$FUNCTIONS_PATH"
-
-# Set all base directories
+# Set subdirectories
 staging_subdir_name=staging
 development_subdir_name=prerelease
-export DEVELOPMENT_PRODUCTION_BASE_DIR="$STABLE_PRODUCTION_BASE_DIR/$development_subdir_name"
 export STABLE_STAGING_BASE_DIR="$STABLE_PRODUCTION_BASE_DIR/$staging_subdir_name"
 export DEVELOPMENT_STAGING_BASE_DIR="$STABLE_PRODUCTION_BASE_DIR/$development_subdir_name/$staging_subdir_name"
 
 # Set base directory depending on the module type:
 if [[ "$MODULE_TYPE" == DEVELOPMENT ]]; then
     if [[ "$DEPLOYMENT_STAGE" == PRODUCTION ]]; then
-        base_dir="$DEVELOPMENT_PRODUCTION_BASE_DIR"
+        # DEVELOPMENT PRODUCTION
+        base_dir="$STABLE_PRODUCTION_BASE_DIR/$development_subdir_name"
     else
+        # DEVELOPMENT STAGING
         base_dir="$DEVELOPMENT_STAGING_BASE_DIR"
     fi
 else
     if [[ "$DEPLOYMENT_STAGE" == PRODUCTION ]]; then
+        # STABLE PRODUCTION
         base_dir="$STABLE_PRODUCTION_BASE_DIR"
     else
+        # STABLE STAGING
         base_dir="$STABLE_STAGING_BASE_DIR"
     fi
 fi
 export BASE_DIR="$base_dir"
 
 ### Export variables needed also when no deployment takes place (e.g., staging files deletion)
+# Path to default files within the repository
+export DEFAULTS_DIR="$REPO_PATH/defaults"
+# Path to the default scripts folder wihtin the repository
+default_scripts_dir="$DEFAULTS_DIR/scripts"
+# Name for the containerised environments root dir
+containerised_envs_root_dir_name=containerised_envs
 # Name of the subdirectory where all apps will be stored
-export APPS_DIR="$BASE_DIR/$APPS_DIR_NAME"
-# Full path of the directory where the containerised environments infrastructure
-# is stored. It usually contains the executable used for environment
-# management/creation, as well as configuration and files for each different 
-# existing environment
-containerised_envs_root_dir="$APPS_DIR/$CONTAINERISED_ENVS_ROOT_DIR_NAME"
+export APPS_DIR="$BASE_DIR/apps"
+# Full path of the directory where the containerised environments infrastructure is stored.
+containerised_envs_root_dir="$APPS_DIR/$containerised_envs_root_dir_name"
 # Path to the directory containing all versions of the app
 export APP_DIR="$containerised_envs_root_dir/envs/$MODULE_NAME"
 # Path to the directory containing the specific version of the app
@@ -79,7 +84,7 @@ if [[ "$DEPLOYMENT_STAGE" == PRODUCTION ]] || [[ "$DEPLOYMENT_STAGE" == STAGING 
     export ENV_OVERRIDES_DIR="$env_folder/overrides"
 
     # Source the specific environment configuration
-    default_config_file="$SCRIPTS_DIR/default_config.sh"
+    default_config_file="$default_scripts_dir/default_config.sh"
     default_env_config_file=$(
         get_overrides_or_defaults "$default_config_file" \
         "No environment configuration script '${default_config_file#$DEFAULTS_DIR/}' found in the repository's defaults or environment overrides."
@@ -100,7 +105,7 @@ if [[ "$DEPLOYMENT_STAGE" == PRODUCTION ]] || [[ "$DEPLOYMENT_STAGE" == STAGING 
 
     # Absolute path where the environment will be located within the container
     # This path is added as an overlay when overlaying the squashfs to the container
-    export INTERNAL_ENV_DIR=${INTERNAL_ENV_DIR:-"/$CONTAINERISED_ENVS_ROOT_DIR_NAME/$MODULE_NAME/$MODULE_VERSION"}
+    export INTERNAL_ENV_DIR=${INTERNAL_ENV_DIR:-"/$containerised_envs_root_dir_name/$MODULE_NAME/$MODULE_VERSION"}
     # Sanity check on INTERNAL_ENV_DIR being an absolute path
     if [[ "$INTERNAL_ENV_DIR" != /* ]]; then
         echo "INTERNAL_ENV_DIR must be an absolute path (must start with a forward slash). Got '$INTERNAL_ENV_DIR'" >&2
@@ -112,7 +117,7 @@ if [[ "$DEPLOYMENT_STAGE" == PRODUCTION ]] || [[ "$DEPLOYMENT_STAGE" == STAGING 
     export TEMP_ENV_DIR="${TEMP_WORKING_DIR}${INTERNAL_ENV_DIR}"
 
     # Full path of the directory where all module files will be stored
-    export ALL_MODULES_DIR="$BASE_DIR/$MODULES_DIR_NAME"
+    export ALL_MODULES_DIR="$BASE_DIR/modules"
     # Full path of the directory where the specific module will be stored
     export MODULE_DIR="$ALL_MODULES_DIR/$MODULE_NAME"
     # Full path of the modulefile
@@ -124,7 +129,7 @@ if [[ "$DEPLOYMENT_STAGE" == PRODUCTION ]] || [[ "$DEPLOYMENT_STAGE" == STAGING 
     # Path of the environment activation script that gets run when users load the module
     export ACTIVATION_SCRIPT_PATH="$MODULE_DIR/$activation_script_name"
     # Path of the default environment activation script within the repository
-    export REPO_ACTIVATION_SCRIPT_PATH="$SCRIPTS_DIR/env_activation.sh"
+    export REPO_ACTIVATION_SCRIPT_PATH="$default_scripts_dir/env_activation.sh"
     # Path to the default modules directory within the repository
     export REPO_MODULES_DIR="$DEFAULTS_DIR/modules"
     # Path to the default modulefile within the repository
@@ -141,10 +146,10 @@ if [[ "$DEPLOYMENT_STAGE" == PRODUCTION ]] || [[ "$DEPLOYMENT_STAGE" == STAGING 
     # Path to the launcher script
     export LAUNCHER_SCRIPT_PATH="$ENV_BIN_DIR/$LAUNCHER_SCRIPT_NAME"
     # Path to the defaults launcher script within the repository
-    export REPO_LAUNCHER_SCRIPT_PATH="$SCRIPTS_DIR/$LAUNCHER_SCRIPT_NAME"
+    export REPO_LAUNCHER_SCRIPT_PATH="$default_scripts_dir/$LAUNCHER_SCRIPT_NAME"
 
     # Path of the deployment post script
-    export DEPLOYMENT_POST_SCRIPT_PATH="$SCRIPTS_DIR/deployment_post_script.sh"
+    export DEPLOYMENT_POST_SCRIPT_PATH="$default_scripts_dir/deployment_post_script.sh"
 
     # Path to the defaults built container image in the repository.
     # This image is automatically built by the build_container_image.yml workflow
@@ -193,10 +198,6 @@ if [[ "$DEPLOYMENT_STAGE" == PRODUCTION ]] || [[ "$DEPLOYMENT_STAGE" == STAGING 
         fi
     fi
     export ENV_FILE="$env_spec_path"
-
-    # Maximum number of DEVELOPMENT module versions to keep in PRODUCTION simultaneously.
-    # If a new deployment causes the total to exceed this limit, the oldest version is deleted.
-    export MAX_DEV_MODULE_VERSIONS=3
 
     ### Micromamba initialisation
     export MAMBA_EXE="${MAMBA_EXE:-}"
@@ -287,7 +288,7 @@ if [[ "$DEPLOYMENT_STAGE" == PRODUCTION ]] || [[ "$DEPLOYMENT_STAGE" == STAGING 
     export HOST_EXECUTABLES="${HOST_EXECUTABLES:-$default_host_executables}"
     
     # Source the additional environment configuration
-    additional_config_file="$SCRIPTS_DIR/additional_config.sh"
+    additional_config_file="$default_scripts_dir/additional_config.sh"
     additional_env_config_file=$(
         get_overrides_or_defaults "$additional_config_file" \
         "No additional environment configuration script '${additional_config_file#$DEFAULTS_DIR/}' found in the repository's defaults or environment overrides."

--- a/infrastructure/scripts/install_config.sh
+++ b/infrastructure/scripts/install_config.sh
@@ -1,4 +1,4 @@
-# Sourced by 'infrastructure/scripts/build_and_deploy_env.sh' to configure the
+# Sourced by 'infrastructure/scripts/build_and_deploy.sh' to configure the
 # build and deployment of the containerised environment.
 
 # Some of the variables defaults in this script can be overridden for a specific environment using the


### PR DESCRIPTION
This PR restructures some parts of the infrastructure for the following purposes:
- Making it easier to pass information (i.e., files and environment variables) between GitHub runner and HPC server
- Make the infrastructure more general and more easily usable by other repos
- Update ssh connections (Fixes #44)
- Change rsync handling. Sometimes rsync is completely removed because the same logic is achieved in a different way. (Fixes #43)


Some of the most relevant specific changes in this PR include:
- Update `set_up_hpc_target` action
- Rename and update `deploy_env.yml` to `deploy_module.yml`
- Rename and update `infrastructure/scripts/build_and_deploy_env.sh` to `infrastructure/scripts/build_and_deploy.sh`
- Rename and update `infrastructure/scripts/write_env_exports.sh` to `infrastructure/scripts/github_runner_env_export.sh`
- Update `infrastructure/scripts/install_config.sh`