### PR TITLE
Added `IS_DEPLOYMENT` env variable

### DIFF
--- a/.github/workflows/deploy_module.yml
+++ b/.github/workflows/deploy_module.yml
@@ -293,6 +293,8 @@ jobs:
             source '${{ env.GH_ENV_EXPORT_SCRIPT }}'
             # Set DEPLOYMENT_STAGE
             export DEPLOYMENT_STAGE=STAGING
+            # Set IS_DEPLOYMENT
+            export IS_DEPLOYMENT=false
             # Delete staging files
             "$INFRA_SCRIPTS_DIR/delete_staging_files.sh" ${{ github.event.number }}
           HPC_SSH_EOF

--- a/infrastructure/scripts/install_config.sh
+++ b/infrastructure/scripts/install_config.sh
@@ -75,7 +75,7 @@ export FILES_MANIFEST_NAME=files_manifest.txt
 export FILES_MANIFEST_PATH="$APP_VERSION_DIR/$FILES_MANIFEST_NAME"
 
 ### Logic that runs only if a deployment is taking place
-if [[ "$DEPLOYMENT_STAGE" == PRODUCTION ]] || [[ "$DEPLOYMENT_STAGE" == STAGING ]]; then
+if [[ "${IS_DEPLOYMENT:-true}" == true ]]; then
     # Create base directory if not present
     mkdir -pv "$BASE_DIR"
 


### PR DESCRIPTION
## Overview
Currently, there is a bug for which the logic that should only run when environments are being deployed (but not when the staging envs are being deleted) implemented [here](https://github.com/ACCESS-NRI/containerised-environments-infra/blob/eeb6c9318e62ab130c77bef6f9781f7bc2ad3d40/infrastructure/scripts/install_config.sh#L77-L78) is always run. This because `DEPLOYMENT_STAGE` is always going to be either `STAGING` or `PRODUCTION`, even in the [delete staging files](https://github.com/ACCESS-NRI/containerised-environments-infra/blob/eeb6c9318e62ab130c77bef6f9781f7bc2ad3d40/.github/workflows/deploy_module.yml#L282) step, because we [export `DEPLOYMENT_STAGE=STAGING`](https://github.com/ACCESS-NRI/containerised-environments-infra/blob/eeb6c9318e62ab130c77bef6f9781f7bc2ad3d40/.github/workflows/deploy_module.yml#L295) (needed within the deletion processing).

This causes unwanted code to run when staging environments are deleted, and at times can cause errors like [this](https://github.com/ACCESS-NRI/containerised-environments-infra/actions/runs/30068616990/job/89404524330#step:12:289).

## Solution
To fix this, I added a `IS_DEPLOYMENT` env variable, that defaults to `true` and is explicitely set to `false` in the "delete staging files" step.