### PR TITLE
Update python version in payu environment

### DIFF
--- a/environments/payu/environment.yml
+++ b/environments/payu/environment.yml
@@ -3,14 +3,12 @@ channels:
   - accessnri
   - conda-forge
 dependencies:
-  - python==3.10
+  - python>=3.13
   - accessnri::payu==1.3.4
   - f90nml
   - nco
   - pytest
   - xarray
-  - mule
-  - um2nc<2
   - accessnri::yamanifest
   - netcdf4=*=nompi_*
   - experiment-generator


### PR DESCRIPTION
## Overview
As discussed in #68:
- [x] Pinned Python version to `python>=3.13`
- [x] Also deleted `mule` and `um2nc` from the environment specification.
   `um2nc` will now be deployed through the [model-processing](https://github.com/ACCESS-NRI/containerised-environments-infra/pull/57) module, therefore we can avoid
   deploying through this `payu` environment as well. This will also simplify environment solving
   and allow to use later versions of Python (`mule` does not support Python versions `>3.12`).