### PR TITLE
Added failsafe when pip is not installed in the python environment

### DIFF
--- a/infrastructure/scripts/generate_env_lock.sh
+++ b/infrastructure/scripts/generate_env_lock.sh
@@ -23,6 +23,9 @@ sed -i -e '/^prefix:/d' \
 # Use awk (with 2 input files) to get pip-installed git packages from pip freeze output,
 # and then replace those in the env lock file
 # and output the final lock file to $ENV_LOCK_FILE_PATH
+# If pip is not installed in the environment, `pip freeze` fails (e.g. "No module
+# named pip"); `|| true` makes the process substitution yield empty output in that
+# case, so no pip-installed git packages get substituted.
 awk '
 # Execute the first set of commands only for the first file (pip freeze output).
 # NR --> Total number of records processed (i.e. lines)
@@ -68,4 +71,4 @@ in_pip && !/^    - / {
 
 # Print all other lines unchanged
 { print }
-' <("$TEMP_ENV_DIR/bin/python3" -m pip freeze) "$temp_env_lock_file" > "$ENV_LOCK_FILE_PATH"
+' <("$TEMP_ENV_DIR/bin/python3" -m pip freeze || true) "$temp_env_lock_file" > "$ENV_LOCK_FILE_PATH"


### PR DESCRIPTION
## Overview
This PR fixes a bug with the command `pip freeze` when `pip` is not installed within the Python environment.
This causes errors like [this one](https://github.com/ACCESS-NRI/containerised-environments-infra/actions/runs/30243071320/job/89905385417#step:5:3943), where the environment lock created is empty and, as a consequence, the environments are still released to production, but with an [empty environment](https://github.com/ACCESS-NRI/containerised-environments-infra/actions/runs/30243071320/job/89905385417#step:6:589) (because the production environment is created using the environment lock produced in the staging job).

## Solution
The solution is to add a failsafe for the `pip freeze` command, so if `pip` is not installed (and the command fails), the failsafe returns true and the whole lockfile generation still goes through, generating the correct file.