### PR TITLE
89 splitnc addmeta

### DIFF
--- a/environments/model-processing/environment.yml
+++ b/environments/model-processing/environment.yml
@@ -5,7 +5,7 @@ channels:
   - nodefaults
 dependencies:
   - python
-  - um2nc==2.1.1
+  - um2nc==2.2.0
   - umfile_utils==1.1.0
   - xarray
   - splitnc==0.2.0

--- a/environments/model-processing/environment.yml
+++ b/environments/model-processing/environment.yml
@@ -9,3 +9,4 @@ dependencies:
   - umfile_utils==1.1.0
   - xarray
   - splitnc
+  - addmeta

--- a/environments/model-processing/environment.yml
+++ b/environments/model-processing/environment.yml
@@ -8,3 +8,4 @@ dependencies:
   - um2nc==2.1.1
   - umfile_utils==1.1.0
   - xarray
+  - splitnc

--- a/environments/model-processing/environment.yml
+++ b/environments/model-processing/environment.yml
@@ -8,5 +8,5 @@ dependencies:
   - um2nc==2.1.1
   - umfile_utils==1.1.0
   - xarray
-  - splitnc
-  - addmeta
+  - splitnc==0.2.0
+  - addmeta==0.5

--- a/environments/model-processing/environment_dev.yml
+++ b/environments/model-processing/environment_dev.yml
@@ -12,3 +12,4 @@ dependencies:
     - git+https://github.com/access-nri/um2nc-standalone.git@main
     - git+https://github.com/access-nri/umfile_utils.git@main
     - git+https://github.com/ACCESS-NRI/splitnc.git@main
+    - git+https://github.com/ACCESS-NRI/addmeta.git@main

--- a/environments/model-processing/environment_dev.yml
+++ b/environments/model-processing/environment_dev.yml
@@ -11,3 +11,4 @@ dependencies:
   - pip:
     - git+https://github.com/access-nri/um2nc-standalone.git@main
     - git+https://github.com/access-nri/umfile_utils.git@main
+    - git+https://github.com/ACCESS-NRI/splitnc.git@main

--- a/environments/model-processing/environment_dev.yml
+++ b/environments/model-processing/environment_dev.yml
@@ -12,4 +12,4 @@ dependencies:
     - git+https://github.com/access-nri/um2nc-standalone.git@main
     - git+https://github.com/access-nri/umfile_utils.git@main
     - git+https://github.com/ACCESS-NRI/splitnc.git@main
-    - git+https://github.com/ACCESS-NRI/addmeta.git@main
+    - git+https://github.com/ACCESS-NRI/addmeta.git@master


### PR DESCRIPTION
This PR adds [splitnc](https://github.com/ACCESS-NRI/splitnc) and [addmeta](https://github.com/ACCESS-NRI/addmeta) to the `model-processing` environment. These tools will be used in ACCESS model postprocessing, and generally will be run alongside `um2nc`.

Closes #89 