### PR TITLE
Add xarray to ants env

### DIFF
--- a/environments/ants/environment.yml
+++ b/environments/ants/environment.yml
@@ -7,3 +7,4 @@ dependencies:
   - python
   - ants==v3.2.0
   - esmf
+  - xarray


### PR DESCRIPTION
As per @Rush74's issue #92, people using the UKMO python packages are also likely to want to use `xarray` at times as well. The intention of this break-off package was to remove the UKMO packages from the main `conda/analysis` environments, as they placed severe restrictions on what versions of other packages could be used. I don't think this extends the scope of the environment outside its original remit.

(Note that I only made a fork since both repo admins are currently on leave, so I can't get write permissions). 