### PR TITLE
Add xarray to ants env

### DIFF
--- a/environments/ants/environment.yml
+++ b/environments/ants/environment.yml
@@ -7,3 +7,4 @@ dependencies:
   - python
   - ants==v3.2.0
   - esmf
+  - xarray


### PR DESCRIPTION
Adds `xarray` to the `ants` environment. The intention of the `ants` environment was not necessarily to isolate `ants`, more to remove the UKMO packages from our deployed conda environments so they aren't held back by said packages, so I think it's fine to add `xarray` to this.